### PR TITLE
Updated google code links to new location on Github

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A collection of ZAP scripts provided by the community, i.e. you lot :)
 Please upload your scripts via pull requests!
 
 For more information on ZAP scripts see:
-* https://code.google.com/p/zaproxy/wiki/HelpAddonsScriptsScripts
-* https://code.google.com/p/zaproxy/wiki/InternalScripting
+* https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsScriptsScripts
+* https://github.com/zaproxy/zaproxy/wiki/InternalScripting
  
 To discuss any aspect of ZAP scripting please join the zaproxy-scripts group: http://groups.google.com/group/zaproxy-scripts
 


### PR DESCRIPTION
The links for additional information about ZAP scripts now reflect their present location on the repo's wiki page and not the old Google code page.

(Extremely small change, more of my OCD than anything)