### PR TITLE
Add scripts to authenticate against MediaWiki sites

### DIFF
--- a/authentication/MediaWikiApiAuthentication.js
+++ b/authentication/MediaWikiApiAuthentication.js
@@ -1,0 +1,99 @@
+/**
+ * Script to authenticate on a MediaWiki site in ZAP via the API.
+ *
+ * MediaWiki protects against Login CSRF using a login token generated
+ * on viewing the login page and storing it in the session and in a
+ * hidden field in the login form. On submitting the login form, the
+ * submitted token and the one in the session are compared to prevent
+ * login CSRF. As a result, ZAP can't currently handle MediaWiki logins
+ * with its form-based authentication. The MediaWiki API can also be used
+ * to authenticate ZAP but it likewise protects against login CSRF by
+ * returning a token on the first login request which must be submitted
+ * on a second login request.
+ *
+ * The required parameter 'API URL' should be set to the path to
+ * api.php, i.e. http://127.0.0.1/w/api.php
+ *
+ * The regex pattern to identify logged in responses could be set to:
+ *     id="pt-logout"
+ *
+ * The regex pattern to identify logged out responses could be set to:
+ *     id="pt-login"
+ *
+ * @author grunny
+ */
+
+function authenticate(helper, paramsValues, credentials) {
+	println("Authenticating via JavaScript script...");
+	importClass(org.parosproxy.paros.network.HttpRequestHeader);
+	importClass(org.parosproxy.paros.network.HttpHeader);
+	importClass(org.apache.commons.httpclient.URI);
+
+	var authHelper = new MWApiAuthenticator(helper, paramsValues, credentials);
+
+	return authHelper.login();
+}
+
+function getRequiredParamsNames(){
+	return ['API URL'];
+}
+
+function getOptionalParamsNames(){
+	return [];
+}
+
+function getCredentialsParamsNames(){
+	return ['Username', 'Password'];
+}
+
+function MWApiAuthenticator(helper, paramsValues, credentials) {
+	this.helper = helper;
+	this.loginApiUrl = paramsValues.get('API URL') + '?action=login&format=json';
+	this.userName = credentials.getParam('Username');
+	this.password = credentials.getParam('Password');
+
+	return this;
+}
+
+MWApiAuthenticator.prototype = {
+	login: function () {
+		var loginToken,
+			requestBody = 'lgname=' + encodeURIComponent(this.userName) +
+				'&lgpassword=' + encodeURIComponent(this.password),
+			response = this.doRequest(
+				this.loginApiUrl,
+				HttpRequestHeader.POST,
+				requestBody
+			),
+			parsedResponse = JSON.parse(response.getResponseBody().toString());
+
+		if (parsedResponse.login.result == 'NeedToken') {
+			loginToken = parsedResponse.login.token;
+			requestBody += '&lgtoken=' + encodeURIComponent(loginToken);
+
+			response = this.doRequest(
+				this.loginApiUrl,
+				HttpRequestHeader.POST,
+				requestBody
+			);
+		}
+
+		return response;
+	},
+
+	doRequest: function (url, requestMethod, requestBody) {
+		var msg,
+			requestUri = new URI(url, false);
+			requestHeader = new HttpRequestHeader(requestMethod, requestUri, HttpHeader.HTTP10);
+
+		msg = this.helper.prepareMessage();
+		msg.setRequestHeader(requestHeader);
+		msg.setRequestBody(requestBody);
+
+		println('Sending ' + requestMethod + ' request to ' + requestUri + ' with body: ' + requestBody);
+		this.helper.sendAndReceive(msg);
+		println("Received response status code for authentication request: " + msg.getResponseHeader().getStatusCode());
+
+		return msg;
+	}
+};

--- a/authentication/MediaWikiAuthentication.js
+++ b/authentication/MediaWikiAuthentication.js
@@ -1,0 +1,117 @@
+/**
+ * Script to authenticate on a MediaWiki site in ZAP via the login form.
+ *
+ * MediaWiki protects against Login CSRF using a login token generated
+ * on viewing the login page and storing it in the session and in a
+ * hidden field in the login form. On submitting the login form, the
+ * submitted token and the one in the session are compared to prevent
+ * login CSRF. As a result, ZAP can't currently handle MediaWiki logins
+ * with its form-based authentication. So, we need to first get the login
+ * token, then use it to perform the login request.
+ *
+ * The required parameter 'Login URL' should be set to the path to
+ * Special:UserLogin, i.e. http://127.0.0.1/wiki/Special:UserLogin
+ *
+ * The regex pattern to identify logged in responses could be set to:
+ *     id="pt-logout"
+ *
+ * The regex pattern to identify logged out responses could be set to:
+ *     id="pt-login"
+ *
+ * @author grunny
+ */
+
+function authenticate(helper, paramsValues, credentials) {
+	println("Authenticating via JavaScript script...");
+	importClass(org.parosproxy.paros.network.HttpRequestHeader);
+	importClass(org.parosproxy.paros.network.HttpHeader);
+	importClass(org.apache.commons.httpclient.URI);
+	importClass(net.htmlparser.jericho.Source);
+
+	var authHelper = new MWAuthenticator(helper, paramsValues, credentials),
+		loginToken = authHelper.getLoginToken();
+
+	return authHelper.doLogin(loginToken);
+}
+
+function getRequiredParamsNames(){
+	return ['Login URL'];
+}
+
+function getOptionalParamsNames(){
+	return [];
+}
+
+function getCredentialsParamsNames(){
+	return ['Username', 'Password'];
+}
+
+function MWAuthenticator(helper, paramsValues, credentials) {
+	this.helper = helper;
+	this.loginUrl = paramsValues.get('Login URL');
+	this.userName = credentials.getParam('Username');
+	this.password = credentials.getParam('Password');
+
+	return this;
+}
+
+MWAuthenticator.prototype = {
+	doLogin: function (loginToken) {
+		var requestBody = 'wpName=' + encodeURIComponent(this.userName) +
+				'&wpPassword=' + encodeURIComponent(this.password) +
+				'&wpLoginToken=' + encodeURIComponent(loginToken),
+			response = this.doRequest(
+				this.loginUrl + (this.loginUrl.indexOf('?') > -1 ? '&' : '?') + 'action=submitlogin&type=login',
+				HttpRequestHeader.POST,
+				requestBody
+			);
+
+		return response;
+	},
+
+	getLoginToken: function () {
+		var response = this.doRequest(this.loginUrl, HttpRequestHeader.GET),
+			loginToken = this.getLoginTokenFromForm(response, 'wpLoginToken');
+
+		return loginToken;
+	},
+
+	doRequest: function (url, requestMethod, requestBody) {
+		var msg,
+			requestInfo,
+			requestUri = new URI(url, false);
+			requestHeader = new HttpRequestHeader(requestMethod, requestUri, HttpHeader.HTTP10);
+
+		requestInfo = 'Sending ' + requestMethod + ' request to ' + requestUri;
+		msg = this.helper.prepareMessage();
+		msg.setRequestHeader(requestHeader);
+
+		if (requestBody) {
+			requestInfo += ' with body: ' + requestBody;
+			msg.setRequestBody(requestBody);
+		}
+
+		println(requestInfo);
+		this.helper.sendAndReceive(msg);
+		println("Received response status code for authentication request: " + msg.getResponseHeader().getStatusCode());
+
+		return msg;
+	},
+
+	getLoginTokenFromForm: function (request, loginTokenName) {
+		var iterator, element, loginToken,
+			pageSource = request.getResponseHeader().toString() + request.getResponseBody().toString(),
+			src = new Source(pageSource),
+			elements = src.getAllElements('input');
+
+		for (iterator = elements.iterator(); iterator.hasNext();) {
+			element = iterator.next();
+			if (element.getAttributeValue('name') == 'wpLoginToken') {
+				loginToken = element.getAttributeValue('value');
+				break;
+			}
+		}
+
+		return loginToken;
+	}
+};


### PR DESCRIPTION
MediaWiki protects against Login CSRF using a login token generated
on viewing the login page and storing it in the session and in a
hidden field in the login form. On submitting the login form, the
submitted token and the one in the session are compared to prevent
login CSRF. As a result, ZAP can't currently handle MediaWiki logins
with its form-based authentication. So, we need to first get the login
token, then use it to perform the login request.

The MediaWiki API can also be used to authenticate ZAP but it likewise
protects against login CSRF by returning a token on the first login request
which must be submitted on a second login request.

This adds two scripts that can be used to authenticate against MediaWiki
sites, one via the login form and the other via the API.