### PR TITLE
Add scripts about CSP policies notification feature and SameSite cookie protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ community-scripts
 
 A collection of ZAP scripts provided by the community, i.e. you lot :)
 
+The easiest way to use this repo in ZAP is to install the 'Community Scripts' add-on from the ZAP Marketplace.
+
+If you might want to contribute to the repo then you can also clone it to a local directory and then add that to ZAP using the Options / Scripts screen.
+
 Please upload your scripts via pull requests!
 
 For more information on ZAP scripts see:

--- a/passive/detect_csp_notif_and_reportonly.js
+++ b/passive/detect_csp_notif_and_reportonly.js
@@ -1,0 +1,77 @@
+/*
+Script to detect if the Content-Security-Policy policies defined for the current site:
+- Send notifications about violations (some kind of monitoring),
+- Behave into "report-only" mode (no blocking, only report violations).
+
+These informations are interesting from an attacker/researcher point of view because it indicates to him:
+1) His input validation probing tentatives will be potentially quickly detected (depending on the monitoring level by site owner),
+2) The CSP policies in place will not block the exploitation if a vulnerability is found into input validation,
+3) Perhaps the endpoint receiving notifications is vulnerable to some injection.
+
+Links:
+- http://content-security-policy.com
+- http://www.html5rocks.com/en/tutorials/security/content-security-policy
+- http://www.html5rocks.com/en/tutorials/security/content-security-policy/#reporting
+
+Author:
+dominique.righetto@gmail.com
+*/
+
+function extractUrl(cspPolicies, cspReportInstruction){
+	//Extract the URL to which any CSP violations are reported
+	//In CSP specification, policies are separated by ';'
+	if(cspPolicies.indexOf(cspReportInstruction) != -1){
+		var startPosition = cspPolicies.search(cspReportInstruction);
+		var tmp = cspPolicies.substring(startPosition);
+		var endPosition = tmp.indexOf(";");
+		if(endPosition != -1){
+			var reportUrl = tmp.substring(0, endPosition);	
+		}else{
+			var reportUrl = tmp;
+		}
+		return reportUrl.replace(cspReportInstruction,"").trim();
+	}else{
+		return null;
+	}
+}
+
+function scan(ps, msg, src) {
+	//Docs on alert raising function:
+	// raiseAlert(risk, int confidence, String name, String description, String uri, 
+	//		String param, String attack, String otherInfo, String solution, String evidence, 
+	//		int cweId, int wascId, HttpMessage msg)
+	// risk: 0: info, 1: low, 2: medium, 3: high
+	// confidence: 0: falsePositive, 1: low, 2: medium, 3: high, 4: confirmed
+
+	//Common variables
+	var cweId = 200; 
+	var wascId = 13;
+	var url = msg.getRequestHeader().getURI().toString();
+	var cspHeaderNames = ["Content-Security-Policy", "X-Content-Security-Policy", "X-Webkit-CSP", "Content-Security-Policy-Report-Only"];
+	var cspReportInstruction = "report-uri";
+
+	//Response headers collection
+	var responseHeaders = msg.getResponseHeader();
+
+	//Detect and analyze presence of the CSP headers
+	for(var i = 0 ; i < cspHeaderNames.length ; i++){
+		var headerName = cspHeaderNames[i];
+		if(responseHeaders.getHeaders(headerName)){
+			//Check if the header values (policies) contains the CSP reporting instruction
+			var headerValues = responseHeaders.getHeaders(headerName).toArray();
+			for(var j = 0 ; j < headerValues.length ; j++){
+				var cspPolicies = headerValues[j].toLowerCase();
+				//Extract the URL to which any CSP violations are reported if specified
+				var reportUrl = extractUrl(cspPolicies, cspReportInstruction);
+				if(reportUrl != null){
+					//Raise info alert
+					var cspWorkingMode = (headerName.toLowerCase().indexOf("-report-only") == -1) ? "BLOCKING" : "REPORTING";
+					var description = "The current site CSP policies defined by HTTP response header '" + headerName + "' (behaving in " + cspWorkingMode + " mode) report violation to '" + reportUrl + "'.";
+					var infoLinkRef = "https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Using_CSP_violation_reports";
+					var solution = "Site owner will be notified at each policies violations, so, start by analyzing if a real monitoring of the notifications is in place before to use fuzzing or to be more aggressive.";
+					ps.raiseAlert(0, 3, "Content Security Policy violations reporting enabled", description, url, "HTTP response header '" + headerName + "'", "", infoLinkRef, solution, headerValues[j], cweId, wascId, msg);
+				}
+			}
+		}
+	}
+}

--- a/passive/detect_samesite_protection.js
+++ b/passive/detect_samesite_protection.js
@@ -1,0 +1,59 @@
+/*
+Script to detect if the site use the protection bring by the "SameSite" cookie attribute.
+
+Knowing that point is interesting because the goal of this attribute is to mitigate CSRF attack.
+
+Links:
+- https://chloe.re/2016/04/13/goodbye-csrf-samesite-to-the-rescue
+- https://tools.ietf.org/html/draft-west-first-party-cookies
+- https://www.chromestatus.com/feature/4672634709082112
+
+Author:
+dominique.righetto@gmail.com
+*/
+
+function scan(ps, msg, src) {
+	//Docs on alert raising function:
+	// raiseAlert(risk, int confidence, String name, String description, String uri, 
+	//		String param, String attack, String otherInfo, String solution, String evidence, 
+	//		int cweId, int wascId, HttpMessage msg)
+	// risk: 0: info, 1: low, 2: medium, 3: high
+	// confidence: 0: falsePositive, 1: low, 2: medium, 3: high, 4: confirmed
+
+	//Common variables
+	var cweId = 352;
+	var wascId = 9;
+	var url = msg.getRequestHeader().getURI().toString();
+	var cookieHeaderNames = ["Set-Cookie", "Set-Cookie2"];
+	var cookieSameSiteAttributeNameLower = "samesite";
+
+	//Response headers collection
+	var responseHeaders = msg.getResponseHeader();
+
+	//Detect and analyze presence of the cookie headers
+	for(var i = 0 ; i < cookieHeaderNames.length ; i++){
+		var headerName = cookieHeaderNames[i];
+		if(responseHeaders.getHeaders(headerName)){
+			//Check if the cookie header values contains the SameSite attribute
+			var headerValues = responseHeaders.getHeaders(headerName).toArray();
+			for(var j = 0 ; j < headerValues.length ; j++){
+				var cookieAttributes = headerValues[j].split(";");
+				//Inspect each attribute in order to avoid false-positive spot
+				//by simply searching "samesite=" on the whole cookie header value...
+				for(var k = 0 ; k < cookieAttributes.length ; k++){
+					var parts = cookieAttributes[k].split("=");
+					if(parts[0].trim().toLowerCase() == cookieSameSiteAttributeNameLower){
+						//Raise info alert
+						var sameSiteAttrValue = parts[1].trim();
+						var cookieName = cookieAttributes[0].split("=")[0].trim();
+						var description = "The current site use the 'SameSite' cookie attribute protection on cookie named '" + cookieName + "', value is set to '" + sameSiteAttrValue + "' protection level.";
+						var infoLinkRef = "https://tools.ietf.org/html/draft-west-first-party-cookies\nhttps://chloe.re/2016/04/13/goodbye-csrf-samesite-to-the-rescue";
+						var solution = "CSRF possible vulnerabilities presents on the site will be mitigated depending on the browser used by the user (browser defines the support level for this cookie attribute).";
+						ps.raiseAlert(0, 3, "SameSite cookie attribute protection used", description, url, "Cookie named: '" + cookieName + "'", "", infoLinkRef, solution, sameSiteAttrValue, cweId, wascId, msg);
+						break;
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION

Hello,

_First script:_
The goal of the proposed script "**detect_samesite_protection.js**" is to detect if the site use the protection bring by the "SameSite" cookie attribute.

Knowing that point is interesting because the goal of this attribute is to mitigate CSRF attack.


_Second script:_
The goal of the proposed script "**detect_csp_notif_and_reportonly.js**" is to detect the following points about CSP policies defined by a site:

- If policies send notifications about violations (some kind of monitoring by the site owner),
- If policies behave into "report-only" mode (no blocking, only report violations).

These informations are interesting from an attacker/researcher point of view because it indicates to him that:

- His input validation probing tentatives will be potentially quickly detected (depending on the monitoring level by site owner),
- The CSP policies in place will not block the exploitation if a vulnerability is found into input validation,
- Perhaps the endpoint receiving notifications is vulnerable to some injection.

Thanks in advance for your feedback.

Regards.