### PR TITLE
Add helper for printing to JS Scripts

### DIFF
--- a/authentication/MediaWikiApiAuthentication.js
+++ b/authentication/MediaWikiApiAuthentication.js
@@ -22,6 +22,10 @@
  *
  * @author grunny
  */
+ 
+// The following handles differences in printing between Java 7's Rhino JS engine
+// and Java 8's Nashorn JS engine
+if (typeof println == 'undefined') this.println = print;
 
 function authenticate(helper, paramsValues, credentials) {
 	println("Authenticating via JavaScript script...");

--- a/authentication/MediaWikiAuthentication.js
+++ b/authentication/MediaWikiAuthentication.js
@@ -21,6 +21,10 @@
  * @author grunny
  */
 
+// The following handles differences in printing between Java 7's Rhino JS engine
+// and Java 8's Nashorn JS engine
+if (typeof println == 'undefined') this.println = print;
+
 function authenticate(helper, paramsValues, credentials) {
 	println("Authenticating via JavaScript script...");
 	importClass(org.parosproxy.paros.network.HttpRequestHeader);

--- a/httpsender/Capture and Replace Anti CSRF Token.js
+++ b/httpsender/Capture and Replace Anti CSRF Token.js
@@ -9,6 +9,10 @@
 
 // REPLACE the values for the variables as applicable to your application.
 
+// The following handles differences in printing between Java 7's Rhino JS engine
+// and Java 8's Nashorn JS engine
+if (typeof println == 'undefined') this.println = print;
+
 // Regular expression for the request URI that returns CSRF token in response.
 // If the application under test returns csrf token in every response or in response to more than request, set a generic regex that matches with host name or domain name of the application.
 // REPLACE the value with RegEx for your application.

--- a/passive/Find Internal IPs.js
+++ b/passive/Find Internal IPs.js
@@ -1,5 +1,9 @@
 // RFC1918 internal IP Finder by freakyclown@gmail.com
 
+// The following handles differences in printing between Java 7's Rhino JS engine
+// and Java 8's Nashorn JS engine
+if (typeof println == 'undefined') this.println = print;
+
 function scan(ps, msg, src) {
     url = msg.getRequestHeader().getURI().toString();
     alertRisk = 2

--- a/proxy/Return fake response.js
+++ b/proxy/Return fake response.js
@@ -2,6 +2,10 @@
 // Note that it requires the change https://code.google.com/p/zaproxy/source/detail?r=5872
 // which is in the trunk, the 2.4 branch and the latest weekly release
 
+// The following handles differences in printing between Java 7's Rhino JS engine
+// and Java 8's Nashorn JS engine
+if (typeof println == 'undefined') this.println = print;
+
 function proxyRequest(msg) {
 	// Change this test to match whatever requests you want to fake
 	if (msg.getRequestHeader().getURI().toString().equals("http://localhost:8080/bodgeit/about.jsp")) {

--- a/standalone/Active scan rule list.js
+++ b/standalone/Active scan rule list.js
@@ -1,5 +1,9 @@
 // This script gives details about all of the active scan rules installed
 
+// The following handles differences in printing between Java 7's Rhino JS engine
+// and Java 8's Nashorn JS engine
+if (typeof println == 'undefined') this.println = print;
+
 extAscan = org.parosproxy.paros.control.Control.getSingleton().
     getExtensionLoader().getExtension(
         org.zaproxy.zap.extension.ascan.ExtensionActiveScan.NAME);

--- a/standalone/Loop through history table.js
+++ b/standalone/Loop through history table.js
@@ -3,6 +3,10 @@
 // Standalone scripts have no template.
 // They are only evaluated when you run them. 
 
+// The following handles differences in printing between Java 7's Rhino JS engine
+// and Java 8's Nashorn JS engine
+if (typeof println == 'undefined') this.println = print;
+
 extHist = org.parosproxy.paros.control.Control.getSingleton().
     getExtensionLoader().getExtension(
         org.parosproxy.paros.extension.history.ExtensionHistory.NAME) 

--- a/standalone/Traverse sites tree.js
+++ b/standalone/Traverse sites tree.js
@@ -3,6 +3,10 @@
 // Standalone scripts have no template.
 // They are only evaluated when you run them. 
 
+// The following handles differences in printing between Java 7's Rhino JS engine
+// and Java 8's Nashorn JS engine
+if (typeof println == 'undefined') this.println = print;
+
 function listChildren(node, level) {
     var i;
     for (i=0;i<level;i++) print ("    ");

--- a/targeted/ElasticSearchExploit.js
+++ b/targeted/ElasticSearchExploit.js
@@ -4,6 +4,10 @@
 // Shoutout to /u/cartogram for the POC rce command
 // Requires elasticsearch running, default port is 9200 check via nmap/portscanner
 
+// The following handles differences in printing between Java 7's Rhino JS engine
+// and Java 8's Nashorn JS engine
+if (typeof println == 'undefined') this.println = print;
+
 function invokeWith(msg) {
 	// give the user some info
 	println('Testing the follwing URL=' + msg.getRequestHeader().getURI().toString()); 

--- a/targeted/Find HTML comments.js
+++ b/targeted/Find HTML comments.js
@@ -1,5 +1,9 @@
 // Targeted scripts can only be invoked by you, the user, eg via a right-click option on the Sites or History tabs
 
+// The following handles differences in printing between Java 7's Rhino JS engine
+// and Java 8's Nashorn JS engine
+if (typeof println == 'undefined') this.println = print;
+
 function invokeWith(msg) {
 	// Debugging can be done using println like this
 	println('Finding comments under ' + msg.getRequestHeader().getURI().toString()); 

--- a/targeted/Find largest subtree.js
+++ b/targeted/Find largest subtree.js
@@ -2,6 +2,10 @@
 // Also reports the total number of sub nodes.
 // Targeted scripts can only be invoked by you, the user, eg via a right-click option on the Sites or History tabs
 
+// The following handles differences in printing between Java 7's Rhino JS engine
+// and Java 8's Nashorn JS engine
+if (typeof println == 'undefined') this.println = print;
+
 tot = 0
 maxparent = ""
 maxsub = 0

--- a/targeted/Remove 302s.js
+++ b/targeted/Remove 302s.js
@@ -3,6 +3,10 @@
 // The default criteria is leaf nodes with a response code of 302 but you can change that to anything you need
 // Targeted scripts can only be invoked by you, the user, eg via a right-click option on the Sites or History tabs
 
+// The following handles differences in printing between Java 7's Rhino JS engine
+// and Java 8's Nashorn JS engine
+if (typeof println == 'undefined') this.println = print;
+
 function recurseDown(sitestree, node) {
 	//println('recurseDown node: ' + node.getHierarchicNodeName() + " " + node.getChildCount())
 	// Loop down through the children first


### PR DESCRIPTION
Further to https://github.com/zaproxy/zaproxy/pull/3138 and related to
zaproxy/zaproxy#3043 update all js scripts that currently leverage
`println()` so that they are able to print as expected when used with Java
8's Nashorn engine.