### PR TITLE
Refer AJAX Spider ID in HTTP Sender README

### DIFF
--- a/httpsender/README.md
+++ b/httpsender/README.md
@@ -23,6 +23,7 @@ They are invoked for proxied requests and requests that originate from ZAP, for 
 // 		7	CHECK_FOR_UPDATES_INITIATOR
 // 		8	BEAN_SHELL_INITIATOR
 // 		9	ACCESS_CONTROL_SCANNER_INITIATOR
+// 		10	AJAX_SPIDER_INITIATOR
 // For the latest list of values see the HttpSender class:
 // https://github.com/zaproxy/zaproxy/blob/master/src/org/parosproxy/paros/network/HttpSender.java
 // 'helper' just has one method at the moment: helper.getHttpSender() which returns the HttpSender 


### PR DESCRIPTION
Change httpsender/README.md to refer the initiator ID of AJAX Spider.
Latest versions of AJAX Spider add-on are already using it.