### PR TITLE
Correct Zest script type

### DIFF
--- a/standalone/Open Fortune 500 websites in a browser.zst
+++ b/standalone/Open Fortune 500 websites in a browser.zst
@@ -4,7 +4,7 @@
   "title": "Open Fortune 500 websites in a browser",
   "description": "A script which opens the Fortune 500 websites in a browser",
   "prefix": "",
-  "type": "Standalone",
+  "type": "StandAlone",
   "parameters": {
     "tokenStart": "{{",
     "tokenEnd": "}}",


### PR DESCRIPTION
Correct the case in the type of a Zest script ("StandAlone" instead of
"Standalone"), with latest version of Zest add-on the type is correctly
checked when asserting if the statements are valid for the script type.