### PR TITLE
Remove message checks in passive scanners

### DIFF
--- a/passive/CookieHTTPOnly.js
+++ b/passive/CookieHTTPOnly.js
@@ -13,18 +13,15 @@ function scan(ps, msg, src)
     wascId = 13
 
     url = msg.getRequestHeader().getURI().toString();
-    if (msg) 
-	{
-		headers = msg.getResponseHeader().getHeaders("Set-Cookie")
-		
-	  if (headers != null)
-		{
-		 re_noflag = /([Hh][Tt][Tt][Pp][Oo][Nn][Ll][Yy])/g
-    		 if (!(re_noflag.test(headers)))
-			{print("here");
-       	 	 ps.raiseAlert(alertRisk, alertReliability, alertTitle, alertDesc, url, '', '', '', alertSolution,headers, cweId, wascId, msg);
-			}
-		}  
-	 }
+    headers = msg.getResponseHeader().getHeaders("Set-Cookie")
+    
+    if (headers != null)
+    {
+        re_noflag = /([Hh][Tt][Tt][Pp][Oo][Nn][Ll][Yy])/g
+        if (!(re_noflag.test(headers)))
+        {
+            ps.raiseAlert(alertRisk, alertReliability, alertTitle, alertDesc, url, '', '', '', alertSolution,headers, cweId, wascId, msg);
+        }
+    }
     
 }

--- a/passive/Find Hashes.js
+++ b/passive/Find Hashes.js
@@ -45,9 +45,6 @@ function scan(ps, msg, src)
     vbull = /(([0-9a-zA-Z]{32}):(S{3,32}))/g //vbulletin
     md45 = /([a-f0-9]{32})/g //md4 and md5 and a bunch of others like tiger
 	
-    if (msg) 
-	
-      {        
 	if (wordpress.test(body)) 
 	  {
 	    wordpress.lastIndex = 0
@@ -147,6 +144,5 @@ function scan(ps, msg, src)
 	      }
 	    ps.raiseAlert(alertRisk[1], alertReliability[1], alertTitle[8], alertDesc[8], url, '', '', foundmd45.toString(), alertSolution[0], '', cweId[0], wascId[0], msg);
 	  }
-     }
 
 }

--- a/passive/SQL injection detection.js
+++ b/passive/SQL injection detection.js
@@ -56,8 +56,6 @@ function scan(ps, msg, src)
 	frontbase = /(Exception (condition )?\d+. Transaction rollback.)/g
 	hsqldb = /(org\.hsqldb\.jdbc|Unexpected end of command in statement \[|Unexpected token.*in statement \[)/g
 
-    if (msg)
-      {
 	if (mysql.test(body))
 	  {
 	    mysql.lastIndex = 0
@@ -200,5 +198,4 @@ function scan(ps, msg, src)
 	      }
             ps.raiseAlert(alertRisk[3], alertReliability[2], alertTitle[13], alertDesc[13], url, '', '', foundhsqldb.toString(), alertSolution[0], '', cweId[0], wascId[0], msg);
 	  }
-     }
 }

--- a/passive/Server Header Disclosure.js
+++ b/passive/Server Header Disclosure.js
@@ -13,14 +13,11 @@ function scan(ps, msg, src)
     wascId = 13
 
     url = msg.getRequestHeader().getURI().toString();
-    if (msg) 
-	{
-		headers = msg.getResponseHeader().getHeaders("Server")
-		
-	  if (headers != null)
-		{
-       	 ps.raiseAlert(alertRisk, alertReliability, alertTitle, alertDesc, url, '', '', '', alertSolution,headers, cweId, wascId, msg);
-		}  
-	 }
+    headers = msg.getResponseHeader().getHeaders("Server")
+    
+    if (headers != null)
+    {
+        ps.raiseAlert(alertRisk, alertReliability, alertTitle, alertDesc, url, '', '', '', alertSolution,headers, cweId, wascId, msg);
+    }
     
 }

--- a/passive/Upload form discovery.js
+++ b/passive/Upload form discovery.js
@@ -14,17 +14,14 @@ function scan(ps, msg, src)
 	
 	uploadForm = /(type\s*=\s*['"]?file['"]?)/g
 	
-	if (msg)
-    {
-		if (uploadForm.test(body))
+	if (uploadForm.test(body))
+	{
+		uploadForm.lastIndex = 0
+		var founduploadForm = []
+		while (comm = uploadForm.exec(body))
 		{
-			uploadForm.lastIndex = 0
-			var founduploadForm = []
-            while (comm = uploadForm.exec(body))
-			{
-				founduploadForm.push(comm[0]);
-			}
-			ps.raiseAlert(alertRisk[0], alertReliability[2], alertTitle[0], alertDesc[0], url, '', '', founduploadForm.toString(), alertSolution[0], '', cweId[0], wascId[0], msg);
+			founduploadForm.push(comm[0]);
 		}
+		ps.raiseAlert(alertRisk[0], alertReliability[2], alertTitle[0], alertDesc[0], url, '', '', founduploadForm.toString(), alertSolution[0], '', cweId[0], wascId[0], msg);
 	}
 }

--- a/passive/X-Powered-By_header_checker.js
+++ b/passive/X-Powered-By_header_checker.js
@@ -13,16 +13,11 @@ function scan(ps, msg, src)
     wascId = 13
 
     url = msg.getRequestHeader().getURI().toString();
-
-    if (msg) 
-	{
-		headers = msg.getResponseHeader().getHeaders("X-Powered-By")
-		
-	  if (headers != null)
-		{
-		
-       	 ps.raiseAlert(alertRisk, alertReliability, alertTitle, alertDesc, url, '', '', '', alertSolution,headers, cweId, wascId, msg);
-		}  
-	 }
+    headers = msg.getResponseHeader().getHeaders("X-Powered-By")
+    
+    if (headers != null)
+    {
+        ps.raiseAlert(alertRisk, alertReliability, alertTitle, alertDesc, url, '', '', '', alertSolution,headers, cweId, wascId, msg);
+    }
     
 }

--- a/passive/clacks.js
+++ b/passive/clacks.js
@@ -13,14 +13,11 @@ function scan(ps, msg, src)
     wascId = 13
 
     url = msg.getRequestHeader().getURI().toString();
-    if (msg) 
-	{
-		headers = msg.getResponseHeader().getHeaders("X-Clacks-Overhead")
-		
-	  if (headers != null)
-		{
-       	 ps.raiseAlert(alertRisk, alertReliability, alertTitle, alertDesc, url, '', '', '', alertSolution,headers, cweId, wascId, msg);
-		}  
-	 }
+    headers = msg.getResponseHeader().getHeaders("X-Clacks-Overhead")
+    
+    if (headers != null)
+    {
+        ps.raiseAlert(alertRisk, alertReliability, alertTitle, alertDesc, url, '', '', '', alertSolution,headers, cweId, wascId, msg);
+    }
     
 }


### PR DESCRIPTION
The messages passed to passive scanners are always defined, it's not
necessary to check them. Also, in CookieHTTPOnly.js remove a (debug?)
print.