### PR TITLE
Fix Duplicate Header in WAF Bypass

### DIFF
--- a/proxy/WAF_Bypass.js
+++ b/proxy/WAF_Bypass.js
@@ -2,6 +2,7 @@
 // conditions allow you to bypass WAF devices.
 // You may need to change the IP addresses for known internal ones, if not defaults may work.
 // This script is best used in conjunction with SQLi or other such attacks.
+// To leverage such bypasses in the fuzzer or active scanner consider leveraging an HttpSender script.
  
 
 function proxyRequest(msg) {
@@ -9,7 +10,7 @@ function proxyRequest(msg) {
 	msg.getRequestHeader().setHeader('X-Remote-IP', "127.0.0.1")
 	msg.getRequestHeader().setHeader('X-Originating-IP', "127.0.0.1")
 	msg.getRequestHeader().setHeader('X-Remote-Addr', "127.0.0.1")
-	msg.getRequestHeader().setHeader('X-Remote-IP', "127.0.0.1")
+	msg.getRequestHeader().setHeader('X-Client-IP', "127.0.0.1")
 	return true
 }
 


### PR DESCRIPTION
Replace second X-Remote-IP entry with X-Client-IP.
Add comment suggesting similar use in an HttpSender script.