### PR TITLE
Update Content-Length after setting body

### DIFF
--- a/active/TestInsecureHTTPVerbs.py
+++ b/active/TestInsecureHTTPVerbs.py
@@ -44,6 +44,7 @@ def PrepareHttpRequest(msg, insecureverb):
 	msg.mutateHttpMethod(insecureverb)
 	if insecureverb == "POST" or insecureverb == "PUT":
 		msg.setRequestBody("bodytext")
+		msg.getRequestHeader().setContentLength(msg.getRequestBody().length());
 	if printdebugmessages:
 		print('After mutating resulting HTTP VERB: -- \t' + msg.getRequestHeader().getMethod() + '\n')
 

--- a/api/sdlc-integration/core/setup_module/proxy_scripts/zapAddCsp.js
+++ b/api/sdlc-integration/core/setup_module/proxy_scripts/zapAddCsp.js
@@ -14,6 +14,7 @@ function proxyResponse(msg) {
 	var url = msg.getRequestHeader().getURI().toString();
 	print('proxyResponse called for url=' + url.substring(0, 80) +"...");
 	// msg.setResponseBody(msg.getResponseBody().toString().replace("Example Domain","Test works"));
+	// msg.getResponseHeader().setContentLength(msg.getResponseBody().length());
 	var relevant = forceEnableEverywhere;
 	for(var i = 0; i<watchedUrlStrings.length; i++) {
 		if(url.indexOf(watchedUrlStrings[i]) > -1) {

--- a/authentication/CasAuthentication.js
+++ b/authentication/CasAuthentication.js
@@ -61,6 +61,7 @@ function authenticate(helper, paramsValues, credentials) {
     var post = helper.prepareMessage();
     post.setRequestHeader(new HttpRequestHeader(HttpRequestHeader.POST, loginUri, HttpHeader.HTTP10));
     post.setRequestBody(requestBody);
+    post.getRequestHeader().setContentLength(post.getRequestBody().length());
     helper.sendAndReceive(post);
     
     /*

--- a/authentication/MagentoAuthentication.js
+++ b/authentication/MagentoAuthentication.js
@@ -63,6 +63,7 @@ function authenticate(helper, paramsValues, credentials) {
     var post = helper.prepareMessage();
     post.setRequestHeader(new HttpRequestHeader(HttpRequestHeader.POST, loginUri, HttpHeader.HTTP10));
     post.setRequestBody(requestBody);
+    post.getRequestHeader().setContentLength(post.getRequestBody().length());
     helper.sendAndReceive(post);
 
     debugMode && print("---- Magento authentication script has finished ----\n");

--- a/authentication/MediaWikiApiAuthentication.js
+++ b/authentication/MediaWikiApiAuthentication.js
@@ -93,6 +93,7 @@ MWApiAuthenticator.prototype = {
 		msg = this.helper.prepareMessage();
 		msg.setRequestHeader(requestHeader);
 		msg.setRequestBody(requestBody);
+		msg.getRequestHeader().setContentLength(msg.getRequestBody().length());
 
 		println('Sending ' + requestMethod + ' request to ' + requestUri + ' with body: ' + requestBody);
 		this.helper.sendAndReceive(msg);

--- a/targeted/request_to_xml.js
+++ b/targeted/request_to_xml.js
@@ -29,6 +29,7 @@ function invokeWith(msg) {
 		body += jsonToXML(js);
 	}
 	msg.setRequestBody(body);
+	msg.getRequestHeader().setContentLength(msg.getRequestBody().length());
 	header = msg.getRequestHeader();
 	header.setHeader(org.parosproxy.paros.network.HttpRequestHeader.CONTENT_TYPE,"application/xml");
 	header.setHeader(org.parosproxy.paros.network.HttpRequestHeader.CONTENT_LENGTH,body.length);

--- a/variant/JsonStrings.js
+++ b/variant/JsonStrings.js
@@ -65,6 +65,7 @@ function setParameter(helper, msg, param, value, escaped) {
 		return;
 	}
 	msg.getRequestBody().setBody(JSON.stringify(obj));
+	msg.getRequestHeader().setContentLength(msg.getRequestBody().length());
 }
 
 function recursive_set(obj, path, value){


### PR DESCRIPTION
Change the scripts to explicitly update the Content-Length after setting
a body (request or response) to not rely on automatic/current behaviour,
which might change to keep and send the messages as they were created.