### PR TITLE
Fix JSON to XML conversion in request_to_xml.js

### DIFF
--- a/targeted/request_to_xml.js
+++ b/targeted/request_to_xml.js
@@ -18,7 +18,7 @@ function invokeWith(msg) {
 	reqb = msg.getRequestBody().toString(); 
 	reqh = msg.getRequestHeader().getURI().toString();
 	if(isJson(reqb)){
-		body += jsonToXML(reqb);
+		body += jsonToXML(JSON.parse(reqb));
 	}
 	else if(ismultipart(msg.getRequestHeader())){
 		js = multiToJson(msg);


### PR DESCRIPTION
Change request_to_xml.js to convert the request body to JSON object when
converting it into XML (instead of leaving it as String), otherwise the
conversion would not work properly, moreover in Rhino it would lead to a
infinite loop (which caused the UI to hang). In Nashorn it would convert
the string, for example:
```JSON
{"a" : "b"}
```
would be converted to:
```XML
<?xml version="1.0" encoding="UTF-8"?>
<0>{</0>
<1>"</1>
<2>a</2>
<3>"</3>
<4> </4>
<5>:</5>
<6> </6>
<7>"</7>
<8>b</8>
<9>"</9>
<10>}</10>
```

(The UI hang was addressed with zaproxy/zap-extensions#1321 - scripts:
do not run targeted scripts in EDT.)