### PR TITLE
Correct lower case comparisons

### DIFF
--- a/passive/detect_csp_notif_and_reportonly.js
+++ b/passive/detect_csp_notif_and_reportonly.js
@@ -17,6 +17,8 @@ Author:
 dominique.righetto@gmail.com
 */
 
+var Locale = Java.type("java.util.Locale");
+
 function extractUrl(cspPolicies, cspReportInstruction){
 	//Extract the URL to which any CSP violations are reported
 	//In CSP specification, policies are separated by ';'
@@ -60,12 +62,12 @@ function scan(ps, msg, src) {
 			//Check if the header values (policies) contains the CSP reporting instruction
 			var headerValues = responseHeaders.getHeaders(headerName).toArray();
 			for(var j = 0 ; j < headerValues.length ; j++){
-				var cspPolicies = headerValues[j].toLowerCase();
+				var cspPolicies = headerValues[j].toLowerCase(Locale.ROOT);
 				//Extract the URL to which any CSP violations are reported if specified
 				var reportUrl = extractUrl(cspPolicies, cspReportInstruction);
 				if(reportUrl != null){
 					//Raise info alert
-					var cspWorkingMode = (headerName.toLowerCase().indexOf("-report-only") == -1) ? "BLOCKING" : "REPORTING";
+					var cspWorkingMode = (headerName.toLowerCase(Locale.ROOT).indexOf("-report-only") == -1) ? "BLOCKING" : "REPORTING";
 					var description = "The current site CSP policies defined by HTTP response header '" + headerName + "' (behaving in " + cspWorkingMode + " mode) report violation to '" + reportUrl + "'.";
 					var infoLinkRef = "https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Using_CSP_violation_reports";
 					var solution = "Site owner will be notified at each policies violations, so, start by analyzing if a real monitoring of the notifications is in place before to use fuzzing or to be more aggressive.";

--- a/passive/detect_samesite_protection.js
+++ b/passive/detect_samesite_protection.js
@@ -12,6 +12,8 @@ Author:
 dominique.righetto@gmail.com
 */
 
+var Locale = Java.type("java.util.Locale");
+
 function scan(ps, msg, src) {
 	//Docs on alert raising function:
 	// raiseAlert(risk, int confidence, String name, String description, String uri, 
@@ -42,7 +44,7 @@ function scan(ps, msg, src) {
 				//by simply searching "samesite=" on the whole cookie header value...
 				for(var k = 0 ; k < cookieAttributes.length ; k++){
 					var parts = cookieAttributes[k].split("=");
-					if(parts[0].trim().toLowerCase() == cookieSameSiteAttributeNameLower){
+					if(parts[0].trim().toLowerCase(Locale.ROOT) == cookieSameSiteAttributeNameLower){
 						//Raise info alert
 						var sameSiteAttrValue = parts[1].trim();
 						var cookieName = cookieAttributes[0].split("=")[0].trim();

--- a/passive/f5_bigip_cookie_internal_ip.js
+++ b/passive/f5_bigip_cookie_internal_ip.js
@@ -11,6 +11,8 @@
 // 20150828 - Initial submission
 // 20160117 - Updated to include ipv6 variants - jkbowser[at]gmail[dot]com
 
+var Locale = Java.type("java.util.Locale");
+
 function scan(ps, msg, src) {
 	//Setup some details we will need for alerts later if we find something
 	alertRisk = [1, 0]
@@ -34,8 +36,8 @@ function scan(ps, msg, src) {
 		for (idx in cookiesArr) {
 			cookieName=cookiesArr[idx].getName();
 			cookieValue=cookiesArr[idx].getValue();
-			if(cookieName.toLowerCase().contains("bigip") &&
-			  !cookieValue.toLowerCase().contains("deleted")) {
+			if(cookieName.toLowerCase(Locale.ROOT).contains("bigip") &&
+			  !cookieValue.toLowerCase(Locale.ROOT).contains("deleted")) {
 				cookieChunks = cookieValue.split("\."); //i.e.: 3860990474.36895.0000
 				//Decode IP
 				try {


### PR DESCRIPTION
Change usage of String.toLowerCase() to use a neutral Locale to avoid
issues with languages that have different characters for lower case.

Related to zaproxy/zaproxy#4327 - ZAP relies on default locale when it
shouldn't