### PR TITLE
Update JavaScript scripts to Nashorn

### DIFF
--- a/active/User defined attacks.js
+++ b/active/User defined attacks.js
@@ -5,10 +5,6 @@
 // Note that new active scripts will initially be disabled
 // Right click the script in the Scripts tree and select "enable"  
 
-// The following handles differences in printing between Java 7's Rhino JS engine
-// and Java 8's Nashorn JS engine
-if (typeof println == 'undefined') this.println = print;
-
 // Replace or extend these with your own attacks
 // put the attacks you most want to run higher, unless you disable the attack strength check
 var attacks = [
@@ -132,8 +128,8 @@ function scanNode(as, msg) {
  * @param {string} value - the original parameter value.
  */
 function scan(as, msg, param, value) {
-	// Debugging can be done using println like this
-	//println('scan called for url=' + msg.getRequestHeader().getURI().toString() + 
+	// Debugging can be done using print like this
+	//print('scan called for url=' + msg.getRequestHeader().getURI().toString() + 
 	//	' param=' + param + ' value=' + value);
 	
 	var max_attacks = attacks.length	// No limit for the "INSANE" level ;)

--- a/authentication/CasAuthentication.js
+++ b/authentication/CasAuthentication.js
@@ -20,20 +20,16 @@
  * @author Hugo Baes <hugo.junior at softplan.com.br>
  * @author Fábio Resner <fabio.resner at softplan.com.br>
  */
+
+// Imports
+var HttpRequestHeader = Java.type("org.parosproxy.paros.network.HttpRequestHeader")
+var HttpHeader = Java.type("org.parosproxy.paros.network.HttpHeader")
+var URI = Java.type("org.apache.commons.httpclient.URI")
+var HttpClientParams = Java.type("org.apache.commons.httpclient.params.HttpClientParams")
+var Pattern = Java.type("java.util.regex.Pattern")
+
 function authenticate(helper, paramsValues, credentials) {
     print("---- CAS authentication script has started ----");
-    
-    // Enable Rhino behavior, in case ZAP is running on Java 8 (which uses Nashorn)
-    if (java.lang.System.getProperty("java.version").startsWith("1.8")) {
-        load("nashorn:mozilla_compat.js");
-    }
-    
-    // Imports
-    importClass(org.parosproxy.paros.network.HttpRequestHeader)
-    importClass(org.parosproxy.paros.network.HttpHeader)
-    importClass(org.apache.commons.httpclient.URI)
-    importClass(org.apache.commons.httpclient.params.HttpClientParams)
-    importClass(java.util.regex.Pattern)
     
     var loginUri = new URI(paramsValues.get("loginUrl"), false);
     

--- a/authentication/MagentoAuthentication.js
+++ b/authentication/MagentoAuthentication.js
@@ -11,6 +11,12 @@
  * @author Max Gopey <gopeyx@gmail.com>
  */
 
+// Imports
+var HttpRequestHeader = Java.type("org.parosproxy.paros.network.HttpRequestHeader");
+var HttpHeader = Java.type("org.parosproxy.paros.network.HttpHeader");
+var URI = Java.type("org.apache.commons.httpclient.URI");
+var Pattern = Java.type("java.util.regex.Pattern");
+
 var debugMode = false;
 
 function getRequiredParamsNames(){
@@ -27,17 +33,6 @@ function getCredentialsParamsNames(){
 
 function authenticate(helper, paramsValues, credentials) {
     debugMode && print("---- Magento authentication script has started ----");
-    
-    // Enable Rhino behavior, in case ZAP is running on Java 8 (which uses Nashorn)
-    if (java.lang.System.getProperty("java.version").startsWith("1.8")) {
-        load("nashorn:mozilla_compat.js");
-    }
-    
-    // Imports
-    importClass(org.parosproxy.paros.network.HttpRequestHeader);
-    importClass(org.parosproxy.paros.network.HttpHeader);
-    importClass(org.apache.commons.httpclient.URI);
-    importClass(java.util.regex.Pattern);
     
     var loginUri = new URI(paramsValues.get("loginUrl"), false);
     

--- a/authentication/MediaWikiApiAuthentication.js
+++ b/authentication/MediaWikiApiAuthentication.js
@@ -23,15 +23,12 @@
  * @author grunny
  */
  
-// The following handles differences in printing between Java 7's Rhino JS engine
-// and Java 8's Nashorn JS engine
-if (typeof println == 'undefined') this.println = print;
+var HttpRequestHeader = Java.type("org.parosproxy.paros.network.HttpRequestHeader");
+var HttpHeader = Java.type("org.parosproxy.paros.network.HttpHeader");
+var URI = Java.type("org.apache.commons.httpclient.URI");
 
 function authenticate(helper, paramsValues, credentials) {
-	println("Authenticating via JavaScript script...");
-	importClass(org.parosproxy.paros.network.HttpRequestHeader);
-	importClass(org.parosproxy.paros.network.HttpHeader);
-	importClass(org.apache.commons.httpclient.URI);
+	print("Authenticating via JavaScript script...");
 
 	var authHelper = new MWApiAuthenticator(helper, paramsValues, credentials);
 
@@ -87,16 +84,16 @@ MWApiAuthenticator.prototype = {
 
 	doRequest: function (url, requestMethod, requestBody) {
 		var msg,
-			requestUri = new URI(url, false);
+			requestUri = new URI(url, false),
 			requestHeader = new HttpRequestHeader(requestMethod, requestUri, HttpHeader.HTTP10);
 
 		msg = this.helper.prepareMessage();
 		msg.setRequestHeader(requestHeader);
 		msg.setRequestBody(requestBody);
 
-		println('Sending ' + requestMethod + ' request to ' + requestUri + ' with body: ' + requestBody);
+		print('Sending ' + requestMethod + ' request to ' + requestUri + ' with body: ' + requestBody);
 		this.helper.sendAndReceive(msg);
-		println("Received response status code for authentication request: " + msg.getResponseHeader().getStatusCode());
+		print("Received response status code for authentication request: " + msg.getResponseHeader().getStatusCode());
 
 		return msg;
 	}

--- a/authentication/MediaWikiAuthentication.js
+++ b/authentication/MediaWikiAuthentication.js
@@ -21,16 +21,13 @@
  * @author grunny
  */
 
-// The following handles differences in printing between Java 7's Rhino JS engine
-// and Java 8's Nashorn JS engine
-if (typeof println == 'undefined') this.println = print;
+var HttpRequestHeader = Java.type("org.parosproxy.paros.network.HttpRequestHeader");
+var HttpHeader = Java.type("org.parosproxy.paros.network.HttpHeader");
+var URI = Java.type("org.apache.commons.httpclient.URI");
+var Source = Java.type("net.htmlparser.jericho.Source");
 
 function authenticate(helper, paramsValues, credentials) {
-	println("Authenticating via JavaScript script...");
-	importClass(org.parosproxy.paros.network.HttpRequestHeader);
-	importClass(org.parosproxy.paros.network.HttpHeader);
-	importClass(org.apache.commons.httpclient.URI);
-	importClass(net.htmlparser.jericho.Source);
+	print("Authenticating via JavaScript script...");
 
 	var authHelper = new MWAuthenticator(helper, paramsValues, credentials),
 		loginToken = authHelper.getLoginToken();
@@ -83,7 +80,7 @@ MWAuthenticator.prototype = {
 	doRequest: function (url, requestMethod, requestBody) {
 		var msg,
 			requestInfo,
-			requestUri = new URI(url, false);
+			requestUri = new URI(url, false),
 			requestHeader = new HttpRequestHeader(requestMethod, requestUri, HttpHeader.HTTP10);
 
 		requestInfo = 'Sending ' + requestMethod + ' request to ' + requestUri;
@@ -96,9 +93,9 @@ MWAuthenticator.prototype = {
 		}
 		msg.getRequestHeader().setContentLength(msg.getRequestBody().length());
 
-		println(requestInfo);
+		print(requestInfo);
 		this.helper.sendAndReceive(msg);
-		println("Received response status code for authentication request: " + msg.getResponseHeader().getStatusCode());
+		print("Received response status code for authentication request: " + msg.getResponseHeader().getStatusCode());
 
 		return msg;
 	},

--- a/authentication/TwoStepAuthentication.js
+++ b/authentication/TwoStepAuthentication.js
@@ -1,7 +1,6 @@
 // Author : aine-rb from Sopra Steria (based on the script of thc202 from the OWASP ZAP development team)
 
 // This script is heavily based on the "Simple Form-Based Authentication.js" template
-// It should be interpreted by the Nashorn engine, since Java 8
 // It can be used to authenticate in a webapplication via a form submission followed by a GET request
 // The submit target for the form, the name of the username field, the name of the password field
 // and the URL of the GET target need to be specified after loading the script.
@@ -23,15 +22,16 @@
 //   credentials - an object containing the credentials values, as configured in the Session Properties - Users panel.
 //                      The credential values can be obtained via calls to the getParam(paramName) method. The param
 //				    names are the ones returned by the getCredentialsParamsNames() below
+
+// Make sure any Java classes used explicitly are imported
+var HttpRequestHeader = Java.type('org.parosproxy.paros.network.HttpRequestHeader');
+var HttpHeader = Java.type('org.parosproxy.paros.network.HttpHeader');
+var URI = Java.type('org.apache.commons.httpclient.URI');
+var AuthenticationHelper = Java.type('org.zaproxy.zap.authentication.AuthenticationHelper');
+var Cookie = Java.type('org.apache.commons.httpclient.Cookie');
+
 function authenticate(helper, paramsValues, credentials) {
     print("Authenticating via JavaScript script...");
-
-    // Make sure any Java classes used explicitly are imported
-    var HttpRequestHeader = Java.type('org.parosproxy.paros.network.HttpRequestHeader');
-    var HttpHeader = Java.type('org.parosproxy.paros.network.HttpHeader');
-    var URI = Java.type('org.apache.commons.httpclient.URI');
-    var AuthenticationHelper = Java.type('org.zaproxy.zap.authentication.AuthenticationHelper');
-    var Cookie = Java.type('org.apache.commons.httpclient.Cookie');
 
     // Prepare the login submission request details
     var requestUri = new URI(paramsValues.get("Submission Form URL"), false);

--- a/extender/HTTP Message Logger.js
+++ b/extender/HTTP Message Logger.js
@@ -1,6 +1,5 @@
 // This script allows to log to a file the HTTP messages sent/received by ZAP.
 // The main methods are "isMessageToLog" and "writeMessage" which tell when and how to log the messages.
-// The script requires Java 8+ (Nashorn engine).
 
 // Declare classes used throughout the script:
 var Integer = Java.type("java.lang.Integer");

--- a/httpfuzzerprocessor/showDifferences.js
+++ b/httpfuzzerprocessor/showDifferences.js
@@ -2,7 +2,7 @@
 //and add the result to the state column!
 //To remove all other states from the state column set the variable `removeOtherStatesFromStateColumn` to `true`.
 //This might be useful if you want to order the column.
-//Script works only with Java 8 and needs Diff add-on
+//Script needs Diff add-on
  
 var DiffTool = Java.type("org.zaproxy.zap.extension.diff.diff_match_patch");
 var key = "script.showDifferences.js";

--- a/httpsender/Alert on HTTP Response Code Errors.js
+++ b/httpsender/Alert on HTTP Response Code Errors.js
@@ -2,10 +2,6 @@
 // By default it will raise 'Info' level alerts for Client Errors (4xx) (apart from 404s) and 'Low' Level alerts for Server Errors (5xx)
 // But it can be easily changed.
 
-// The following handles differences in printing between Java 7's Rhino JS engine
-// and Java 8's Nashorn JS engine
-if (typeof println == 'undefined') this.println = print;
-
 pluginid = 100000	// https://github.com/zaproxy/zaproxy/blob/develop/src/doc/scanners.md
 
 function sendingRequest(msg, initiator, helper) {

--- a/httpsender/Capture and Replace Anti CSRF Token.js
+++ b/httpsender/Capture and Replace Anti CSRF Token.js
@@ -9,10 +9,6 @@
 
 // REPLACE the values for the variables as applicable to your application.
 
-// The following handles differences in printing between Java 7's Rhino JS engine
-// and Java 8's Nashorn JS engine
-if (typeof println == 'undefined') this.println = print;
-
 // Regular expression for the request URI that returns CSRF token in response.
 // If the application under test returns csrf token in every response or in response to more than request, set a generic regex that matches with host name or domain name of the application.
 // REPLACE the value with RegEx for your application.
@@ -41,40 +37,40 @@ var cookieParamType = org.parosproxy.paros.network.HtmlParameter.Type.cookie;
 // REPLACE the value with the params to scan for CSRF token and replace with latest vaule.
 var parameterTypesList = [formParamType, urlParamType, cookieParamType];
 
-//println ("AntiCsrfTokenValue: " + org.zaproxy.zap.extension.script.ScriptVars.getGlobalVar("anti.csrf.token.value"))
+//print ("AntiCsrfTokenValue: " + org.zaproxy.zap.extension.script.ScriptVars.getGlobalVar("anti.csrf.token.value"))
 
 function sendingRequest(msg, initiator, helper) {
-    // println('sendingRequest called for url=' + msg.getRequestHeader().getURI().toString())
+    // print('sendingRequest called for url=' + msg.getRequestHeader().getURI().toString())
     var numberOfParameterTypes = parameterTypesList.length;
     for (var index=0; index < numberOfParameterTypes; index++) {
         if (parameterTypesList[index] != null && parameterTypesList[index] === formParamType) {
             var formParams = msg.getFormParams();
-            // println ("Form Params before update: " + formParams);
+            // print ("Form Params before update: " + formParams);
             var updatedFormParams = modifyParams(formParams);
-            // println ("Form Params after update: " + updatedFormParams);
+            // print ("Form Params after update: " + updatedFormParams);
             msg.setFormParams(updatedFormParams);
         } else if (parameterTypesList[index] != null && parameterTypesList[index] === urlParamType) {
             var urlParams = msg.getUrlParams();
-            // println ("Url Params before update: " + urlParams);
+            // print ("Url Params before update: " + urlParams);
             var updatedUrlParams = modifyParams(urlParams);
-            // println ("Url Params after update: " + updatedUrlParams);
+            // print ("Url Params after update: " + updatedUrlParams);
             msg.setGetParams(updatedUrlParams);
         } else if (parameterTypesList[index] != null && parameterTypesList[index] === cookieParamType) {
             var cookieParams = msg.getCookieParams();
-            // println ("Cookie Params before update: " + cookieParams);
+            // print ("Cookie Params before update: " + cookieParams);
             var updatedCookieParams = modifyParams(cookieParams);
-            // println ("Cookie Params after update: " + updatedCookieParams);
+            // print ("Cookie Params after update: " + updatedCookieParams);
             msg.setCookieParams(updatedCookieParams);
         }
     }
 }
 
 function responseReceived(msg, initiator, helper) {
-    // println('responseReceived called for url=' + msg.getRequestHeader().getURI().toString())
+    // print('responseReceived called for url=' + msg.getRequestHeader().getURI().toString())
     if (msg.getRequestHeader().getURI().toString().match(urlRegEx) != null) {
         var csrfTokenValue = msg.getResponseBody().toString().match(csrfTokenValueRegEx);
         if (csrfTokenValue != null && csrfTokenValue.length > matcherGroupNumber) {
-            println('Latest CSRF Token value: ' + csrfTokenValue[matcherGroupNumber]);
+            print('Latest CSRF Token value: ' + csrfTokenValue[matcherGroupNumber]);
             org.zaproxy.zap.extension.script.ScriptVars.setGlobalVar("anti.csrf.token.value", csrfTokenValue[matcherGroupNumber]);
         }
     }

--- a/httpsender/README.md
+++ b/httpsender/README.md
@@ -32,16 +32,16 @@ They are invoked for proxied requests and requests that originate from ZAP, for 
 // New requests can be made like this:
 // msg2 = msg.cloneAll() // msg2 can then be safely changed as required without affecting msg
 // helper.getHttpSender().sendAndReceive(msg2, false);
-// println('msg2 response=' + msg2.getResponseHeader().getStatusCode())
+// print('msg2 response=' + msg2.getResponseHeader().getStatusCode())
 
 function sendingRequest(msg, initiator, helper) {
-	// Debugging can be done using println like this
-	println('sendingRequest called for url=' + msg.getRequestHeader().getURI().toString())
+	// Debugging can be done using print like this
+	print('sendingRequest called for url=' + msg.getRequestHeader().getURI().toString())
 }
 
 function responseReceived(msg, initiator, helper) {
-	// Debugging can be done using println like this
-	println('responseReceived called for url=' + msg.getRequestHeader().getURI().toString())
+	// Debugging can be done using print like this
+	print('responseReceived called for url=' + msg.getRequestHeader().getURI().toString())
 }
 ```
 ## Variables

--- a/passive/Find Internal IPs.js
+++ b/passive/Find Internal IPs.js
@@ -1,9 +1,5 @@
 // RFC1918 internal IP Finder by freakyclown@gmail.com
 
-// The following handles differences in printing between Java 7's Rhino JS engine
-// and Java 8's Nashorn JS engine
-if (typeof println == 'undefined') this.println = print;
-
 function scan(ps, msg, src) {
     url = msg.getRequestHeader().getURI().toString();
     alertRisk = 2
@@ -19,7 +15,7 @@ function scan(ps, msg, src) {
 
 
     // you can tell the user in the console we are doing stuff by uncommenting the line below
-    //println('Finding IPs Under: ' + url);
+    //print('Finding IPs Under: ' + url);
 
     // lets check its not one of the files types that are never likely to contain stuff, like pngs and jpegs
     contenttype = msg.getResponseHeader().getHeader("Content-Type")

--- a/passive/Report non static sites.js
+++ b/passive/Report non static sites.js
@@ -4,10 +4,6 @@
 // Note that new passive scripts will initially be disabled
 // Right click the script in the Scripts tree and select "enable"  
 
-// The following handles differences in printing between Java 7's Rhino JS engine
-// and Java 8's Nashorn JS engine
-if (typeof println == 'undefined') this.println = print;
-
 /**
  * Passively scans an HTTP message. The scan function will be called for 
  * request/response made via ZAP, actual messages depend on the function

--- a/passive/Telerik Using Poor Crypto.js
+++ b/passive/Telerik Using Poor Crypto.js
@@ -4,8 +4,6 @@
 // (c) 2017 Harrison Neal
 // http://www.apache.org/licenses/LICENSE-2.0
 
-if (typeof println == 'undefined') this.println = print;
-
 function scan(ps, msg, src) {
 	alertRisk = org.parosproxy.paros.core.scanner.Alert.RISK_HIGH;
 	alertTitle = "Telerik UI for ASP.NET AJAX CVE-2017-9248 Cryptographic Weakness";

--- a/proxy/Drop requests not in scope.js
+++ b/proxy/Drop requests not in scope.js
@@ -1,6 +1,4 @@
 // This script drops ALL requests that are out of scope
-// Note that it requires the change https://code.google.com/p/zaproxy/source/detail?r=5872
-// which is in the trunk, the 2.4 branch and the latest weekly release
 
 function proxyRequest(msg) {
 

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -23,8 +23,8 @@ To access requests that originate from ZAP use httpsender scripts.
  * @param msg - the HTTP request being proxied. This is an HttpMessage object.
  */
 function proxyRequest(msg) {
-	// Debugging can be done using println like this
-	println('proxyRequest called for url=' + msg.getRequestHeader().getURI().toString())
+	// Debugging can be done using print like this
+	print('proxyRequest called for url=' + msg.getRequestHeader().getURI().toString())
 	
 	return true
 }
@@ -35,8 +35,8 @@ function proxyRequest(msg) {
  * @param msg - the HTTP response being proxied. This is an HttpMessage object.
  */
 function proxyResponse(msg) {
-	// Debugging can be done using println like this
-	println('proxyResponse called for url=' + msg.getRequestHeader().getURI().toString())
+	// Debugging can be done using print like this
+	print('proxyResponse called for url=' + msg.getRequestHeader().getURI().toString())
 	return true
 }
 ```

--- a/proxy/Replace in request or response body.js
+++ b/proxy/Replace in request or response body.js
@@ -9,17 +9,13 @@
 // Note that new proxy scripts will initially be disabled
 // Right click the script in the Scripts tree and select "enable"  
 
-// The following handles differences in printing between Java 7's Rhino JS engine
-// and Java 8's Nashorn JS engine
-if (typeof println == 'undefined') this.println = print;
-
 /**
  * This function allows interaction with proxy requests (i.e.: outbound from the browser/client to the server).
  * 
  * @param msg - the HTTP request being proxied. This is an HttpMessage object.
  */
 function proxyRequest(msg) {
-	println('proxyRequest called for url=' + msg.getRequestHeader().getURI().toString())
+	print('proxyRequest called for url=' + msg.getRequestHeader().getURI().toString())
 	// Remove the '(?i)' for a case exact match
 	var req_str_to_change = "(?i)change from this"
 	var req_str_to_replace = "changed to this"
@@ -36,7 +32,7 @@ function proxyRequest(msg) {
  * @param msg - the HTTP response being proxied. This is an HttpMessage object.
  */
 function proxyResponse(msg) {
-	println('proxyResponse called for url=' + msg.getRequestHeader().getURI().toString())
+	print('proxyResponse called for url=' + msg.getRequestHeader().getURI().toString())
 	// Remove the '(?i)' for a case exact match
 	var req_str_to_change = "(?i)change from this"
 	var req_str_to_replace = "changed to this"

--- a/proxy/Return fake response.js
+++ b/proxy/Return fake response.js
@@ -1,16 +1,10 @@
 // This script allow you to return 'fake' responses for any requests you like.
-// Note that it requires the change https://code.google.com/p/zaproxy/source/detail?r=5872
-// which is in the trunk, the 2.4 branch and the latest weekly release
-
-// The following handles differences in printing between Java 7's Rhino JS engine
-// and Java 8's Nashorn JS engine
-if (typeof println == 'undefined') this.println = print;
 
 function proxyRequest(msg) {
 	// Change this test to match whatever requests you want to fake
 	if (msg.getRequestHeader().getURI().toString().equals("http://localhost:8080/bodgeit/about.jsp")) {
 
-		println('Faking response for url ' + msg.getRequestHeader().getURI().toString())
+		print('Faking response for url ' + msg.getRequestHeader().getURI().toString())
 
 		msg.setResponseBody("<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 3.2//EN\">\n" +
 			"<html><head></head><body><h1>Hack</h1>\n" +

--- a/standalone/Active scan rule list.js
+++ b/standalone/Active scan rule list.js
@@ -1,29 +1,25 @@
 // This script gives details about all of the active scan rules installed
 
-// The following handles differences in printing between Java 7's Rhino JS engine
-// and Java 8's Nashorn JS engine
-if (typeof println == 'undefined') this.println = print;
-
 extAscan = org.parosproxy.paros.control.Control.getSingleton().
     getExtensionLoader().getExtension(
         org.zaproxy.zap.extension.ascan.ExtensionActiveScan.NAME);
 
 plugins = extAscan.getPolicyManager().getDefaultScanPolicy().getPluginFactory().getAllPlugin().toArray();
 
-println('\n');
+print('\n');
 
 for (var i=0; i < plugins.length; i++) {
   try {
-    println ('Plugin ID: ' + plugins[i].getId());
-    println ('Name: ' + plugins[i].getName());
-    println ('Desc: ' + plugins[i].getDescription());
-    println ('Risk: ' + plugins[i].getRisk());
-    println ('Soln: ' + plugins[i].getSolution());
-    println ('Ref:  ' + plugins[i].getReference());
-    println ('CWE:  ' + plugins[i].getCweId());
-    println ('WASC:  ' + plugins[i].getWascId());
-    println ('');
+    print ('Plugin ID: ' + plugins[i].getId());
+    print ('Name: ' + plugins[i].getName());
+    print ('Desc: ' + plugins[i].getDescription());
+    print ('Risk: ' + plugins[i].getRisk());
+    print ('Soln: ' + plugins[i].getSolution());
+    print ('Ref:  ' + plugins[i].getReference());
+    print ('CWE:  ' + plugins[i].getCweId());
+    print ('WASC:  ' + plugins[i].getWascId());
+    print ('');
   } catch (e) {
-    println (e);
+    print (e);
   }
 }

--- a/standalone/Loop through history table.js
+++ b/standalone/Loop through history table.js
@@ -3,10 +3,6 @@
 // Standalone scripts have no template.
 // They are only evaluated when you run them. 
 
-// The following handles differences in printing between Java 7's Rhino JS engine
-// and Java 8's Nashorn JS engine
-if (typeof println == 'undefined') this.println = print;
-
 extHist = org.parosproxy.paros.control.Control.getSingleton().
     getExtensionLoader().getExtension(
         org.parosproxy.paros.extension.history.ExtensionHistory.NAME) 
@@ -18,7 +14,7 @@ if (extHist != null) {
         hr = extHist.getHistoryReference(i)
         if (hr) { 
             url = hr.getHttpMessage().getRequestHeader().getURI().toString();
-            println('Got History record id ' + hr.getHistoryId() + ' URL=' + url); 
+            print('Got History record id ' + hr.getHistoryId() + ' URL=' + url); 
         }
         i++
     }

--- a/standalone/Run report.js
+++ b/standalone/Run report.js
@@ -1,7 +1,7 @@
 // Script for generating a ZAP report in xml of html format
 
 // set up some useful vars
-model = org.parosproxy.paros.model.Model().getSingleton();
+model = org.parosproxy.paros.model.Model.getSingleton();
 rls = new org.parosproxy.paros.extension.report.ReportLastScan();
 
 // code for generating an xml report and storing it in a var

--- a/standalone/Traverse sites tree.js
+++ b/standalone/Traverse sites tree.js
@@ -3,16 +3,11 @@
 // Standalone scripts have no template.
 // They are only evaluated when you run them. 
 
-// The following handles differences in printing between Java 7's Rhino JS engine
-// and Java 8's Nashorn JS engine
-if (typeof println == 'undefined') this.println = print;
-
 function listChildren(node, level) {
-    var i;
-    for (i=0;i<level;i++) print ("    ");
-    var j;
-    for (j=0;j<node.getChildCount();j++) {
-        println(node.getChildAt(j).getNodeName());
+    var indentation = "";
+    for (var i=0;i<level;i++) indentation += "    ";
+    for (var j=0;j<node.getChildCount();j++) {
+        print(indentation + node.getChildAt(j).getNodeName());
         listChildren(node.getChildAt(j), level+1);
     }
 }

--- a/targeted/ElasticSearchExploit.js
+++ b/targeted/ElasticSearchExploit.js
@@ -4,14 +4,10 @@
 // Shoutout to /u/cartogram for the POC rce command
 // Requires elasticsearch running, default port is 9200 check via nmap/portscanner
 
-// The following handles differences in printing between Java 7's Rhino JS engine
-// and Java 8's Nashorn JS engine
-if (typeof println == 'undefined') this.println = print;
-
 function invokeWith(msg) {
 	// give the user some info
-	println('Testing the follwing URL=' + msg.getRequestHeader().getURI().toString()); 
-	println('');
+	print('Testing the follwing URL=' + msg.getRequestHeader().getURI().toString()); 
+	print('');
 	// grab the request header so we can check for path/query and append if needed
 	httpRequestHeader = msg.getRequestHeader()
 	uri=httpRequestHeader.getURI()
@@ -32,11 +28,11 @@ function invokeWith(msg) {
 	// update the length to take in account of the changes
 	msg.getRequestHeader().setContentLength(msg.getRequestBody().length());
 	// create a new sender
-	sender = org.parosproxy.paros.network.HttpSender(org.parosproxy.paros.model.Model.getSingleton().getOptionsParam().getConnectionParam(), true, 6)
+	sender = new org.parosproxy.paros.network.HttpSender(org.parosproxy.paros.model.Model.getSingleton().getOptionsParam().getConnectionParam(), true, 6)
 	// send our new request
 	sender.sendAndReceive(msg)
 		
 	// output the response to the console
-	println(msg.getResponseBody());
+	print(msg.getResponseBody());
 
 }		

--- a/targeted/Find HTML comments.js
+++ b/targeted/Find HTML comments.js
@@ -1,12 +1,8 @@
 // Targeted scripts can only be invoked by you, the user, eg via a right-click option on the Sites or History tabs
 
-// The following handles differences in printing between Java 7's Rhino JS engine
-// and Java 8's Nashorn JS engine
-if (typeof println == 'undefined') this.println = print;
-
 function invokeWith(msg) {
-	// Debugging can be done using println like this
-	println('Finding comments under ' + msg.getRequestHeader().getURI().toString()); 
+	// Debugging can be done using print like this
+	print('Finding comments under ' + msg.getRequestHeader().getURI().toString()); 
 	prefix = msg.getRequestHeader().getURI().toString();
 
 	extHist = org.parosproxy.paros.control.Control.getSingleton().
@@ -22,11 +18,11 @@ function invokeWith(msg) {
 				body = hr.getHttpMessage().getResponseBody().toString()
 				// Look for html comments
 				if (body.indexOf('<!--') > 0) {
-		           	print(hr.getHttpMessage().getRequestHeader().getURI() + "\n") 
+		           	print(hr.getHttpMessage().getRequestHeader().getURI()) 
 					o = body.indexOf('<!--');
 					while (o > 0) {
 						e = body.indexOf('-->', o);
-			           	print("\t" + body.substr(o,e-o+3) + "\n") 
+			           	print("\t" + body.substr(o,e-o+3)) 
 						o = body.indexOf('<!--', e);
 					}
 				}

--- a/targeted/Find largest subtree.js
+++ b/targeted/Find largest subtree.js
@@ -2,16 +2,12 @@
 // Also reports the total number of sub nodes.
 // Targeted scripts can only be invoked by you, the user, eg via a right-click option on the Sites or History tabs
 
-// The following handles differences in printing between Java 7's Rhino JS engine
-// and Java 8's Nashorn JS engine
-if (typeof println == 'undefined') this.println = print;
-
 tot = 0
 maxparent = ""
 maxsub = 0
 
 function recurseDown(node) {
-	//println('recurseDown node: ' + node.getHierarchicNodeName() + " " + node.getChildCount())
+	//print('recurseDown node: ' + node.getHierarchicNodeName() + " " + node.getChildCount())
 	tot++
 	if (node.getChildCount() > maxsub) {
 		maxsub = node.getChildCount();
@@ -25,24 +21,24 @@ function recurseDown(node) {
 
 
 function invokeWith(msg) {
-	// Debugging can be done using println like this
-	//println('invokeWith called for url=' + msg.getRequestHeader().getURI().toString())
+	// Debugging can be done using print like this
+	//print('invokeWith called for url=' + msg.getRequestHeader().getURI().toString())
 
 	sitestree = org.parosproxy.paros.model.Model.getSingleton().getSession().getSiteTree()
 	node = sitestree.findNode(msg, true)
 
 	if (node != null) {
-		//println('found node: ' + node.getHierarchicNodeName())
+		//print('found node: ' + node.getHierarchicNodeName())
 		recurseDown(node)
 		tot -- // to remove the top node
 
-		println('Largest subtree under ' + node.getHierarchicNodeName() + ' is')
-		println('\t' + maxparent)
-		println('With ' + maxsub + ' immediate sub nodes')
-		println('Total number of sub nodes = ' + tot)
+		print('Largest subtree under ' + node.getHierarchicNodeName() + ' is')
+		print('\t' + maxparent)
+		print('With ' + maxsub + ' immediate sub nodes')
+		print('Total number of sub nodes = ' + tot)
 
 	} else {
-		println('Failed to find node:( ')
+		print('Failed to find node:( ')
 	}
 
 }

--- a/targeted/Remove 302s.js
+++ b/targeted/Remove 302s.js
@@ -3,12 +3,8 @@
 // The default criteria is leaf nodes with a response code of 302 but you can change that to anything you need
 // Targeted scripts can only be invoked by you, the user, eg via a right-click option on the Sites or History tabs
 
-// The following handles differences in printing between Java 7's Rhino JS engine
-// and Java 8's Nashorn JS engine
-if (typeof println == 'undefined') this.println = print;
-
 function recurseDown(sitestree, node) {
-	//println('recurseDown node: ' + node.getHierarchicNodeName() + " " + node.getChildCount())
+	//print('recurseDown node: ' + node.getHierarchicNodeName() + " " + node.getChildCount())
 	// Loop down through the children first
 	var j;
 	for (j=0;j<node.getChildCount();j++) {
@@ -18,7 +14,7 @@ function recurseDown(sitestree, node) {
 		}
 	}
 	if (deleteThis(node)) {
-		println('Removing node: ' + node.getHierarchicNodeName())
+		print('Removing node: ' + node.getHierarchicNodeName())
 		org.zaproxy.zap.extension.history.PopupMenuPurgeSites.purge(sitestree, node)
 		return true
 	}
@@ -40,14 +36,14 @@ function deleteThis(node) {
 }
 
 function invokeWith(msg) {
-	// Debugging can be done using println like this
-	//println('invokeWith called for url=' + msg.getRequestHeader().getURI().toString())
+	// Debugging can be done using print like this
+	//print('invokeWith called for url=' + msg.getRequestHeader().getURI().toString())
 
 	sitestree = org.parosproxy.paros.model.Model.getSingleton().getSession().getSiteTree()
 	node = sitestree.findNode(msg, true)
 
 	if (node != null) {
-		//println('found node: ' + node.getHierarchicNodeName())
+		//print('found node: ' + node.getHierarchicNodeName())
 		recurseDown(sitestree, node)
 	}
 

--- a/targeted/json_csrf_poc_generator.js
+++ b/targeted/json_csrf_poc_generator.js
@@ -23,7 +23,7 @@ function invokeWith(msg) {
 	if(body.length()!=0)
 	if(!isJson(body)){	
 	if(ismultipart(msg.getRequestHeader())){
-		type 	=  msg.getRequestHeader().getHeader(org.parosproxy.paros.network.HttpRequestHeader.CONTENT_TYPE);
+		type 	=  msg.getRequestHeader().getHeader(org.parosproxy.paros.network.HttpHeader.CONTENT_TYPE);
 		delim 	=  type.substring(type.search("=")+1,type.length());
 		h = body.split("--"+delim);
 		k=0;
@@ -90,7 +90,7 @@ function isJson(str)
 }
 
 function ismultipart(header){
-	type = header.getHeader(org.parosproxy.paros.network.HttpRequestHeader.CONTENT_TYPE);
+	type = header.getHeader(org.parosproxy.paros.network.HttpHeader.CONTENT_TYPE);
 	if(type == null )
 		return false;
 	if(type.contains("multipart/form-data"))

--- a/targeted/request_to_xml.js
+++ b/targeted/request_to_xml.js
@@ -8,8 +8,7 @@
 // released under the Apache v2.0 licence.
 // You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 // Author : @haseebeqx (GitHub, Twitter)
-// tested on: ZAP 2.4.1
-// note : due to a bug in mozilla Rhino  bdy.charAt(j) had to be replaced with String.fromCharCode(bdy.charAt(j)). so in future (or in Nashorn) you may have to change it back
+// tested on: ZAP 2.7.0
 // rule1: pure JSON , no CODE
 // rule2: correct body (make edits only after conversion)
 
@@ -30,8 +29,8 @@ function invokeWith(msg) {
 	}
 	msg.setRequestBody(body);
 	header = msg.getRequestHeader();
-	header.setHeader(org.parosproxy.paros.network.HttpRequestHeader.CONTENT_TYPE,"application/xml");
-	header.setHeader(org.parosproxy.paros.network.HttpRequestHeader.CONTENT_LENGTH,body.length);
+	header.setHeader(org.parosproxy.paros.network.HttpHeader.CONTENT_TYPE,"application/xml");
+	header.setHeader(org.parosproxy.paros.network.HttpHeader.CONTENT_LENGTH,body.length);
 	msg.setRequestHeader(header);
 	ext = new org.parosproxy.paros.extension.history.ExtensionHistory;
 	man = ext.getResendDialog();
@@ -50,7 +49,7 @@ function isJson(str){
 }
 
 function ismultipart(header){
-	type = header.getHeader(org.parosproxy.paros.network.HttpRequestHeader.CONTENT_TYPE);
+	type = header.getHeader(org.parosproxy.paros.network.HttpHeader.CONTENT_TYPE);
 	if(type == null )
 		return false;
 	if(type.contains("multipart/form-data"))
@@ -74,26 +73,26 @@ function bodyToJson(body){
 				if(first){
 					out += '{ "'
 					af = '' ;			
-					while(String.fromCharCode(bdy.charAt(j)) != '[' && String.fromCharCode(bdy.charAt(j)) != '=' ){
+					while(bdy.charAt(j) != '[' && bdy.charAt(j) != '=' ){
 						if(j == len)
 							break;
-						out += String.fromCharCode(bdy.charAt(j))
+						out += bdy.charAt(j)
 						j++;
 					}
 					out += '" :';
 					af += '} ';
 					first = false;
 				}
-				if(String.fromCharCode(bdy.charAt(j)) == '=' && !opend){
+				if(bdy.charAt(j) == '=' && !opend){
 					j++;
 					out += '"'+bdy.substring(j,len)+'"';
 					break;
 					continue;
 				}	
-				else if(String.fromCharCode(bdy.charAt(j)) == '[' && !opend){
+				else if(bdy.charAt(j) == '[' && !opend){
 					opend = true;
 					out += '{ "';
-					if(String.fromCharCode(bdy.charAt(j+1)) == ']' && String.fromCharCode(bdy.charAt(j+2)) == '='){
+					if(bdy.charAt(j+1) == ']' && bdy.charAt(j+2) == '='){
 						j += 2;
 						out += '"'+bdy.substring(j,len)+'"';
 						af += '} '
@@ -101,14 +100,14 @@ function bodyToJson(body){
 					}
 					continue;
 				}
-				else if(String.fromCharCode(bdy.charAt(j)) == ']'){
+				else if(bdy.charAt(j) == ']'){
 					out += '" :';
 					af += " }"
 					opend = false;
 					continue;
 				}
 				else if(opend){
-					out += String.fromCharCode(bdy.charAt(j))
+					out += bdy.charAt(j)
 					continue;
 				}
 				else {
@@ -123,10 +122,10 @@ function bodyToJson(body){
 	}
 	else{
 		pairs = body.split('&');
-		pairs.forEach(function(i, pair){
+		for each(pair in pairs){
 			pair = pair.split('=');
 			result[pair[0]] = decodeURIComponent(pair[1]||'');
-			});	
+		}
 	}
 return result;	
 }
@@ -158,7 +157,7 @@ function toXml(key,value,att){ //pretify
 		}
 }
 function multiToJson(msg){
-		type =  msg.getRequestHeader().getHeader(org.parosproxy.paros.network.HttpRequestHeader.CONTENT_TYPE);
+		type =  msg.getRequestHeader().getHeader(org.parosproxy.paros.network.HttpHeader.CONTENT_TYPE);
 		delim =  type.substring(type.search("=")+1,type.length());
 		h = msg.getRequestBody().toString().split("--"+delim);
 		k=0;
@@ -195,26 +194,26 @@ function multiToJson(msg){
 				first = true;
 				for(ii=0;ii<len;ii++){
 					if(first){
-						while(String.fromCharCode(bdy.charAt(ii)) != '[' && ii < len){
-							out += String.fromCharCode(bdy.charAt(ii));
+						while(bdy.charAt(ii) != '[' && ii < len){
+							out += bdy.charAt(ii);
 							ii++;	
 						}
 					first = false;
 					out += '" '
 					}
-					if(String.fromCharCode(bdy.charAt(ii)) == '[' && !opened ){
+					if(bdy.charAt(ii) == '[' && !opened ){
 						out += ' :{ "' ;
 						opened = true;
 						continue;
 					} 
-					if(String.fromCharCode(bdy.charAt(ii)) == ']' && opened){
+					if(bdy.charAt(ii) == ']' && opened){
 						out += '"';
 						af += '}';
 						opened = false;
 						continue;
 					}
 					if(opened){
-						out += String.fromCharCode(bdy.charAt(ii));
+						out += bdy.charAt(ii);
 					}
 				}
 				out += ':"'+values[i]+'"'+af;

--- a/variant/JsonStrings.js
+++ b/variant/JsonStrings.js
@@ -4,10 +4,6 @@
 // Note that new custom input vector scripts will initially be disabled
 // Right click the script in the Scripts tree and select "enable"  
 
-// The following handles differences in printing between Java 7's Rhino JS engine
-// and Java 8's Nashorn JS engine
-if (typeof println == 'undefined') this.println = print;
-
 /*
 This variant script can be used as an alternative to the default JSON input vectors
 when one only wants to scan the string fields of the JSON object, not integers.


### PR DESCRIPTION
Update JavaScript scripts (and examples in READMEs) to Nashorn:
 - Remove Nashorn `println` workarounds;
 - Remove comments that mentioned Java 8 or Nashorn as requirement, now
   all of them require the newer engine (per ZAP targeted Java version);
 - Use `print` instead of `println`;
 - Import classes using `Java.type`;
 - Correct declaration of variables in the same statement, fix loops and
   char comparisons;
 - Correct access to constants/methods from extending classes (e.g.
   `HttpHeader` instead of `HttpRequestHeader`, `InetAddress` instead of
   `Inet4Address`);
 - Correct access to classes (e.g. `Model` instead of `Model()`) and
   instantiations (e.g. use `new`).

Related to zaproxy/zaproxy#3470 - Move to using Java 8.