### PR TITLE
Update link to scanners.md

### DIFF
--- a/httpsender/Alert on HTTP Response Code Errors.js
+++ b/httpsender/Alert on HTTP Response Code Errors.js
@@ -2,7 +2,7 @@
 // By default it will raise 'Info' level alerts for Client Errors (4xx) (apart from 404s) and 'Low' Level alerts for Server Errors (5xx)
 // But it can be easily changed.
 
-pluginid = 100000	// https://github.com/zaproxy/zaproxy/blob/develop/src/doc/scanners.md
+pluginid = 100000	// https://github.com/zaproxy/zaproxy/blob/develop/docs/scanners.md
 
 function sendingRequest(msg, initiator, helper) {
 	// Nothing to do


### PR DESCRIPTION
Update a link to scanners.md.

Part of zaproxy/zaproxy#4672 - Move (non-dist) doc files to top level
directory