### PR TITLE
Inject JS even if media type does not have params

### DIFF
--- a/httpsender/inject_js_in_html_page.js
+++ b/httpsender/inject_js_in_html_page.js
@@ -30,7 +30,7 @@ function responseReceived(msg, initiator, helper) {
 
     xRequestedWith = msg.getRequestHeader().getHeader('X-Requested-With');
     contentType = header.getHeader('Content-Type');
-    contentTypeRegex = new RegExp(/text\/html;/g);
+    contentTypeRegex = new RegExp(/text\/html/g);
     indexOfHead = bodyAsStr.indexOf('<head>');
 
     if (!contentTypeRegex.test(contentType)


### PR DESCRIPTION
Change inject_js_in_html_page.js to inject the script even if the media
type does not have any parameters (it does not require any).