### PR TITLE
Remove unused imports

### DIFF
--- a/api/mass-baseline/mass-basescore.py
+++ b/api/mass-baseline/mass-basescore.py
@@ -3,7 +3,6 @@
 from __future__ import print_function
 import os
 import sys
-import subprocess
 import traceback
 
 def parse_results (site, date, is_summary_file, file):

--- a/api/sdlc-integration/core/config.py
+++ b/api/sdlc-integration/core/config.py
@@ -9,7 +9,6 @@ target_auth = {
 	"pw": "bar"
 }
 
-import getpass
 # Create prefilled credentials for Jira bugtacker
 jira_auth = {
 	"user": "foo",

--- a/api/sdlc-integration/core/scan_module/scan.py
+++ b/api/sdlc-integration/core/scan_module/scan.py
@@ -25,7 +25,6 @@ import sys
 import time
 import requests
 from datetime import datetime
-from zapv2 import ZAPv2
 import core.config as config
 import core.shared as shared
 

--- a/api/sdlc-integration/core/setup_module/zap_session.py
+++ b/api/sdlc-integration/core/setup_module/zap_session.py
@@ -11,7 +11,6 @@ import getopt
 import logging
 import sys
 import urlparse
-from zapv2 import ZAPv2
 import core.shared as shared
 
 logging.basicConfig(level=logging.INFO)

--- a/standalone/WebSocketExportToOrg.py
+++ b/standalone/WebSocketExportToOrg.py
@@ -37,9 +37,7 @@ Export Format:
 """
 
 from org.parosproxy.paros.control import Control
-from org.parosproxy.paros.extension.history import ExtensionHistory
 from org.zaproxy.zap.extension.websocket import ExtensionWebSocket
-from org.zaproxy.zap.extension.websocket import WebSocketChannelDTO
 from org.zaproxy.zap.extension.websocket import WebSocketMessageDTO
 from org.zaproxy.zap.extension.websocket.utility import InvalidUtf8Exception
 

--- a/standalone/window_creation_template.js
+++ b/standalone/window_creation_template.js
@@ -1,7 +1,6 @@
 //Template for GUI creation
 
 var absframe = Java.type("org.parosproxy.paros.view.AbstractFrame");
-var jpanel = Java.type("javax.swing.JPanel");
 var jlabel = Java.type("javax.swing.JLabel");
 var jmenubar = Java.type("javax.swing.JMenuBar");
 var jmenu = Java.type("javax.swing.JMenu");

--- a/standalone/window_creation_template.py
+++ b/standalone/window_creation_template.py
@@ -4,7 +4,6 @@ Template for GUI creation - ported for Python/Jython
 """ 
 
 from org.parosproxy.paros.view import AbstractFrame;
-from javax.swing import JPanel;
 from javax.swing import JLabel;
 from javax.swing import JMenuBar;
 from javax.swing import JMenu;


### PR DESCRIPTION
Remove unused imports in Python and JavaScript scripts.

Issues reported by `lgtm.com`.