### PR TITLE
Assert all script files are tested

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,12 @@ dependencies {
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.2.0")
 
     testImplementation("org.assertj:assertj-core:3.11.0")
+    testImplementation("org.apache.commons:commons-lang3:3.8")
 
+    testRuntimeOnly("org.zaproxy:zap:2.7.0")
+
+    testImplementation("org.codehaus.groovy:groovy-all:2.4.14")
+    testImplementation("org.jruby:jruby-complete:1.7.4")
     testImplementation("org.python:jython-standalone:2.7.1")
 }
 


### PR DESCRIPTION
Assert that no files remain after testing all scripts to ensure the
files present are either scripts (with expected extension) or known
non-script files (e.g. README.md).
Also, add remaining script engines, JRuby and Groovy.