### PR TITLE
Tidy up Multiple Security Header Check

### DIFF
--- a/passive/Mutliple Security Header Check.js
+++ b/passive/Mutliple Security Header Check.js
@@ -2,8 +2,8 @@
 
 
 function scan(ps, msg, src) {
-    var url = msg.getRequestHeader().getURI().toString();
-    var body = msg.getResponseHeader().toString()
+    var url = msg.getRequestHeader().getURI().toString()
+    var responseHeader = msg.getResponseHeader().toString()
     var alertRisk = [0, 1, 2, 3] //0=informational, 1=low, 2=medium, 3=high
     var alertReliability = [0, 1, 2, 3, 4] //0=fp,1=low,2=medium,3=high,4=confirmed
     var alertTitle = ["Strict Transport Security(STS) Header Not Set (script)",
@@ -33,34 +33,43 @@ function scan(ps, msg, src) {
     // test sts
     if (msg.getRequestHeader().isSecure()) {
         if (msg.getResponseHeader().getHeaders("Strict-Transport-Security") == null)
-            ps.raiseAlert(alertRisk[1], alertReliability[3], alertTitle[0], alertDesc[0], url, '', '', '', alertSolution[0], '', cweId[0], wascId[0], msg);
+            ps.raiseAlert(alertRisk[1], alertReliability[3], alertTitle[0], alertDesc[0], url, '', '', '', alertSolution[0], '', cweId[0], wascId[0], msg)
     }
     // test csp
-    if (msg.getResponseHeader().getHeaders(("Content-Security-Policy" && "X-Content-Security-Policy" && "X-WebKit-CSP")) == null)
-        ps.raiseAlert(alertRisk[1], alertReliability[3], alertTitle[1], alertDesc[1], url, '', '', '', alertSolution[1], '', cweId[0], wascId[0], msg);
+    if (!hasAnyHeader(msg.getResponseHeader(), ["Content-Security-Policy", "X-Content-Security-Policy", "X-WebKit-CSP"]))
+        ps.raiseAlert(alertRisk[1], alertReliability[3], alertTitle[1], alertDesc[1], url, '', '', '', alertSolution[1], '', cweId[0], wascId[0], msg)
 
 
     // test xxs protection
     var re_xss = /(X\-XSS\-Protection\:.+1)/g
-    if (!(re_xss.test(body))) //if its false
+    if (!(re_xss.test(responseHeader))) //if its false
     {
-        ps.raiseAlert(alertRisk[1], alertReliability[3], alertTitle[2], alertDesc[2], url, '', '', '', alertSolution[2], '', cweId[0], wascId[0], msg);
+        ps.raiseAlert(alertRisk[1], alertReliability[3], alertTitle[2], alertDesc[2], url, '', '', '', alertSolution[2], '', cweId[0], wascId[0], msg)
     }
 
     // test xcontent no sniff protection
     var re_nosniff = /(X\-Content\-Type\-Options\:.*nosniff.*)/g
-    if (!(re_nosniff.test(body))) //if its false
+    if (!(re_nosniff.test(responseHeader))) //if its false
     {
-        ps.raiseAlert(alertRisk[2], alertReliability[2], alertTitle[3], alertDesc[3], url, '', '', '', alertSolution[3], '', cweId[0], wascId[0], msg);
+        ps.raiseAlert(alertRisk[2], alertReliability[2], alertTitle[3], alertDesc[3], url, '', '', '', alertSolution[3], '', cweId[0], wascId[0], msg)
     }
 
     // test xcontent no sniff protection
     var re_clickjack = /(X\-Frame\-Options\:.+[Dd][Ee][Nn][Yy])/g
-    if (!(re_clickjack.test(body))) //if its false
+    if (!(re_clickjack.test(responseHeader))) //if its false
     {
-        ps.raiseAlert(alertRisk[1], alertReliability[3], alertTitle[4], alertDesc[4], url, '', '', '', alertSolution[4], '', cweId[0], wascId[0], msg);
+        ps.raiseAlert(alertRisk[1], alertReliability[3], alertTitle[4], alertDesc[4], url, '', '', '', alertSolution[4], '', cweId[0], wascId[0], msg)
     }
 
 
 
+}
+
+function hasAnyHeader(header, headers) {
+    for (var i in headers) {
+        if (header.getHeader(headers[i])) {
+            return true
+        }
+    }
+    return false
 }


### PR DESCRIPTION
Correct CSP header check (which was just checking the last one not all).
Remove unnecessary semicolons.
Correct variable name, from body to responseHeader.

Issues reported by `lgtm.com`.