### PR TITLE
Update JavaDoc links

### DIFF
--- a/httpfuzzerprocessor/README.md
+++ b/httpfuzzerprocessor/README.md
@@ -69,7 +69,7 @@ function processResult(utils, fuzzResult){
 ## Parameters
 | Name | JavaDoc |
 | --- | --- |
-| message | [HttpMessage](http://www.zaproxy.org/2.5/javadocs/org/parosproxy/paros/network/HttpMessage.html) |
+| message | [HttpMessage](https://static.javadoc.io/org.zaproxy/zap/2.7.0/org/parosproxy/paros/network/HttpMessage.html) |
 
 ## Code Links
 | Name | Source |

--- a/httpsender/README.md
+++ b/httpsender/README.md
@@ -47,9 +47,9 @@ function responseReceived(msg, initiator, helper) {
 ## Variables
 | Name | Javadocs |
 | --- | --- |
-| msg | [HttpMessage](http://www.zaproxy.org/2.5/javadocs/org/parosproxy/paros/network/HttpMessage.html) |
+| msg | [HttpMessage](https://static.javadoc.io/org.zaproxy/zap/2.7.0/org/parosproxy/paros/network/HttpMessage.html) |
 | initiator | int |
-| helper | [HttpSenderScriptHelper](http://www.zaproxy.org/2.5/javadocs/org/zaproxy/zap/extension/script/HttpSenderScriptHelper.html) |
+| helper | [HttpSenderScriptHelper](https://static.javadoc.io/org.zaproxy/zap/2.7.0/org/zaproxy/zap/extension/script/HttpSenderScriptHelper.html) |
 
 ## Code Links
 * [HttpSenderScript.java](https://github.com/zaproxy/zaproxy/blob/master/src/org/zaproxy/zap/extension/script/HttpSenderScript.java)

--- a/payloadgenerator/README.md
+++ b/payloadgenerator/README.md
@@ -66,5 +66,5 @@ function close() {
 ```
 
 ## Useful Links
-* [String](https://docs.oracle.com/javase/7/docs/api/java/lang/String.html)
+* [String](https://docs.oracle.com/javase/8/docs/api/java/lang/String.html)
 

--- a/payloadprocessor/README.md
+++ b/payloadprocessor/README.md
@@ -29,4 +29,4 @@ function process(payload) {
 ## Parameters
 | Name | JavaDoc |
 | --- | --- |
-| payload | [String](https://docs.oracle.com/javase/7/docs/api/java/lang/String.html) |
+| payload | [String](https://docs.oracle.com/javase/8/docs/api/java/lang/String.html) |

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -43,7 +43,7 @@ function proxyResponse(msg) {
 ## Variables
 | Name | Javadocs |
 | --- | --- |
-| msg | [HttpMessage](http://www.zaproxy.org/2.5/javadocs/org/parosproxy/paros/network/HttpMessage.html) |
+| msg | [HttpMessage](https://static.javadoc.io/org.zaproxy/zap/2.7.0/org/parosproxy/paros/network/HttpMessage.html) |
 
 ## Code Links
 * [ProxyScript.java](https://github.com/zaproxy/zaproxy/blob/master/src/org/zaproxy/zap/extension/script/ProxyScript.java)


### PR DESCRIPTION
Update JavaDoc links to latest ZAP version and targeted Java version.