### PR TITLE
Update Alert on Unexpected Content Types

### DIFF
--- a/httpsender/Alert on Unexpected Content Types.js
+++ b/httpsender/Alert on Unexpected Content Types.js
@@ -14,6 +14,8 @@ var extensionAlert = org.parosproxy.paros.control.Control.getSingleton().getExte
 var expectedTypes = [
 		"application/json",
 		"application/octet-stream",
+		"application/problem+json",
+		"application/problem+xml",
 		"application/soap+xml",
 		"application/xml",
 		"application/x-yaml",


### PR DESCRIPTION
Add the following Content-Types to list of expected ones:
 - `application/problem+json`;
 - `application/problem+xml`.

Related to zaproxy/zaproxy#5121 - Unexpected Content (Type was returned)
 - incompatible with RFC 7807