### PR TITLE
[Find Emails.js] Improve E-Mail detection regex

### DIFF
--- a/passive/Find Emails.js
+++ b/passive/Find Emails.js
@@ -5,6 +5,7 @@
 // 20150106 - Updated by kingthorin+owaspzap@gmail.com to handle addresses (such as gmail) with alias portion:
 //     https://support.google.com/mail/answer/12096?hl=en
 //     https://regex101.com/r/sH4vC0/2
+// 20181213 - Update by nil0x42+owaspzap@gmail.com to ignore false positives (such as '*@123' or '$@#!.')
 
 function scan(ps, msg, src) {
     // first lets set up some details incase we find an email, these will populate the alert later
@@ -18,7 +19,7 @@ function scan(ps, msg, src) {
 
 	// lets build a regular expression that can find email addresses
 	// the regex must appear within /( and )/g
-    var re = /([a-zA-Z0-9.#?$*_\+-]+@[a-zA-Z0-9.#?$*_-]+.[a-zA-Z0-9.-]+)/g
+    var re = /([a-zA-Z0-9_.+-]+@[a-zA-Z0-9]+[a-zA-Z0-9-]*\.[a-zA-Z0-9-.]*[a-zA-Z0-9]{2,})/g
 
 	// we need to set the url variable to the request or we cant track the alert later
     var url = msg.getRequestHeader().getURI().toString();


### PR DESCRIPTION
- ignores false positives such as '*@123' or '$@#!.'
- still detects e-mails with '+' portion
- checks domain portion correctness