### PR TITLE
 find_reflected_params: refactor & optimize code

### DIFF
--- a/passive/find_reflected_params.py
+++ b/passive/find_reflected_params.py
@@ -7,28 +7,28 @@ Note that new passive scripts will initially be disabled
 Right click the script in the Scripts tree and select "enable"
 """  
 def compare(paramvalue_pair,msg): 
-	reflected=''
-	if len(paramvalue_pair.split('=',1))>1:
-		value=paramvalue_pair.split('=',1)
-		body=msg.getResponseBody().toString()
-		header=msg.getResponseHeader().toString()
-		if (value[1] in body or value[1] in header) and value[1] != '' and len(value[1])>7: 
-			reflected=value
-	return reflected
+    reflected=''
+    if len(paramvalue_pair.split('=',1))>1:
+        value=paramvalue_pair.split('=',1)
+        body=msg.getResponseBody().toString()
+        header=msg.getResponseHeader().toString()
+        if (value[1] in body or value[1] in header) and value[1] != '' and len(value[1])>7: 
+            reflected=value
+    return reflected
 
 def scan(ps, msg, src): 
-	alertTitle='Reflected HTTP GET parameter(s)'
-	alertDesc='Reflected parameter value has been found. A reflected parameter values may introduce XSS vulnerability or HTTP header injection.'
-	reflected_params=''
-	URI=msg.getRequestHeader().getURI();
-	query=URI.getQuery();
-	if query:
-		uriofreflected_param=URI.toString()
-		paramvalue_pair=query.split('&');
-		i=0;
-		while(i<len(paramvalue_pair)):
-			if(compare(paramvalue_pair[i],msg)):
-				reflected_params=reflected_params  + compare(paramvalue_pair[i],msg)[0] + ','
-			i=i+1;
-		if(reflected_params):
-			ps.raiseAlert(0, 2, alertTitle, alertDesc, uriofreflected_param, reflected_params, '', '', '', '', 0, 0, msg);
+    alertTitle='Reflected HTTP GET parameter(s)'
+    alertDesc='Reflected parameter value has been found. A reflected parameter values may introduce XSS vulnerability or HTTP header injection.'
+    reflected_params=''
+    URI=msg.getRequestHeader().getURI();
+    query=URI.getQuery();
+    if query:
+        uriofreflected_param=URI.toString()
+        paramvalue_pair=query.split('&');
+        i=0;
+        while(i<len(paramvalue_pair)):
+            if(compare(paramvalue_pair[i],msg)):
+                reflected_params=reflected_params  + compare(paramvalue_pair[i],msg)[0] + ','
+            i=i+1;
+        if(reflected_params):
+            ps.raiseAlert(0, 2, alertTitle, alertDesc, uriofreflected_param, reflected_params, '', '', '', '', 0, 0, msg);

--- a/passive/find_reflected_params.py
+++ b/passive/find_reflected_params.py
@@ -5,30 +5,52 @@ The scan function will be called for request/response made via ZAP, excluding so
 Passive scan rules should not make any requests 
 Note that new passive scripts will initially be disabled
 Right click the script in the Scripts tree and select "enable"
-"""  
-def compare(paramvalue_pair,msg): 
-    reflected=''
-    if len(paramvalue_pair.split('=',1))>1:
-        value=paramvalue_pair.split('=',1)
-        body=msg.getResponseBody().toString()
-        header=msg.getResponseHeader().toString()
-        if (value[1] in body or value[1] in header) and value[1] != '' and len(value[1])>7: 
-            reflected=value
-    return reflected
+
+Refactored & Improved by nil0x42
+"""
+
+# Set to True if you want to see results on a per param basis
+#  (i.e.: A single URL may be listed more than once)
+RESULT_PER_FINDING = False
+
+# Ignore parameters whose length is too short
+MIN_PARAM_VALUE_LENGTH = 8
+
 
 def scan(ps, msg, src): 
-    alertTitle='Reflected HTTP GET parameter(s)'
-    alertDesc='Reflected parameter value has been found. A reflected parameter values may introduce XSS vulnerability or HTTP header injection.'
-    reflected_params=''
-    URI=msg.getRequestHeader().getURI();
-    query=URI.getQuery();
-    if query:
-        uriofreflected_param=URI.toString()
-        paramvalue_pair=query.split('&');
-        i=0;
-        while(i<len(paramvalue_pair)):
-            if(compare(paramvalue_pair[i],msg)):
-                reflected_params=reflected_params  + compare(paramvalue_pair[i],msg)[0] + ','
-            i=i+1;
-        if(reflected_params):
-            ps.raiseAlert(0, 2, alertTitle, alertDesc, uriofreflected_param, reflected_params, '', '', '', '', 0, 0, msg);
+    # Docs on alert raising function:
+    #  raiseAlert(int risk, int confidence, str name, str description, str uri,
+    #               str param, str attack, str otherInfo, str solution,
+    # 		   str evidence, int cweId, int wascId, HttpMessage msg)
+    #  risk: 0: info, 1: low, 2: medium, 3: high
+    #  confidence: 0: falsePositive, 1: low, 2: medium, 3: high, 4: confirmed
+    alert_title = "Reflected HTTP GET parameter(s) (script)"
+    alert_desc = ("Reflected parameter value has been found. "
+                  "A reflected parameter values may introduce XSS "
+                  "vulnerability or HTTP header injection.")
+
+    uri = header = body = None
+    reflected_params = []
+
+    for param in msg.getUrlParams():
+        value = param.getValue()
+        if len(value) < MIN_PARAM_VALUE_LENGTH:
+            continue
+
+        if not header:
+            uri = msg.getRequestHeader().getURI().toString()
+            header = msg.getResponseHeader().toString()
+            body = msg.getResponseBody().toString()
+
+        if value in header or value in body:
+            if RESULT_PER_FINDING:
+                param_name = param.getName()
+                ps.raiseAlert(0, 2, alert_title, alert_desc, uri, param_name,
+                        None, None, None, value, 0, 0, msg)
+            else:
+                reflected_params.append(param.getName())
+
+    if reflected_params and not RESULT_PER_FINDING:
+        reflected_params = u",".join(reflected_params)
+        ps.raiseAlert(0, 2, alert_title, alert_desc, uri, reflected_params,
+                None, None, None, None, 0, 0, msg)


### PR DESCRIPTION
refactoring & optimization:
---------------------------
1. previous script was loading useless & greedy buffers
   reapeatedly, without being necessary.
   compare() function was called twice per check,
   and body & header buffers re-created lot of times.

2. query parameters are now parsed using zaproxy built-in
   method getUrlParams() instead of reinventing the wheel.

new features:
-------------
1. Add a `RESULT_PER_FINDING` boolean which lets user choose
   if he prefers to have results per reflected parameter,
   with evidence string properly hihglighter.
   (defaults to False)
2. Add a `MIN_PARAM_VALUE_LENGTH` int which lets user choose
   from which length parameter values will be checked
   (defaults to 8)