### PR TITLE
HUNT.py: refactor, improve perf & readability, fix bugs

### DIFF
--- a/passive/HUNT.py
+++ b/passive/HUNT.py
@@ -15,9 +15,6 @@ def appliesToHistoryType(histType):
 
 
 def scan(ps, msg, src):
-    if ScriptVars.getGlobalVar("hunt") is None:
-        ScriptVars.setGlobalVar("hunt","init")
-
     words_dlp = ['access','admin','dbg','debug','edit','grant','test','alter','clone','create','delete','disable','enable','exec','execute','load','make','modify','rename','reset','shell','toggle','adm','root','cfg','config']
     words_pfi = ['file','document','folder','root','path','pg','style','pdf','template','php_path','doc']
     words_pidor = ['id','user','account','number','order','no','doc','key','email','group','profile','edit','report']
@@ -34,94 +31,96 @@ def scan(ps, msg, src):
     if not params or not base_uri:
         return
 
-    base_uri = str( base_uri.group() )
-    regex = base_uri + str(params)
-    globalvar = ScriptVars.getGlobalVar("hunt")
+    base_uri = base_uri.group()
+    urlParam_repr = base_uri + str(params)
+    globalvar = max(ScriptVars.getGlobalVar("hunt"), "")
 
-    if regex not in globalvar:
-        ScriptVars.setGlobalVar("hunt","" + globalvar + ' , ' + regex)
+    if urlParam_repr in globalvar:
+        return
 
-        # Searching Debug and Logic
-        result = []
-        for x in words_dlp:
-            y = re.compile(".*"+x)
-            if len(filter(y.match, params))>0:
-                result.append(x)
+    ScriptVars.setGlobalVar("hunt", globalvar + ' , ' + urlParam_repr)
 
-        if result:
-            ps.raiseAlert(0, 1, 'Possible Debug & Logic Parameters', 'HUNT located the' + ','.join(result) + ' parameter inside of your application traffic. The ' + ','.join(result) + ' parameter is most often associated to debug,  access, or critical functionality in applications. \nHUNT recommends further manual analysis of the parameter in question.',
-            msg.getRequestHeader().getURI().toString(),
-            ','.join(result), '', msg.getRequestHeader().toString()+'\n'+msg.getRequestBody().toString(), '', '', 0, 0, msg);
+    # Searching Debug and Logic
+    result = []
+    for x in words_dlp:
+        y = re.compile(".*"+x)
+        if len(filter(y.match, params))>0:
+            result.append(x)
 
-        # Searching File Inclusion
-        result = []
-        for x in words_pfi:
-            y = re.compile(".*"+x)
-            if len(filter(y.match, params))>0:
-                result.append(x)
+    if result:
+        ps.raiseAlert(0, 1, 'Possible Debug & Logic Parameters', 'HUNT located the' + ','.join(result) + ' parameter inside of your application traffic. The ' + ','.join(result) + ' parameter is most often associated to debug,  access, or critical functionality in applications. \nHUNT recommends further manual analysis of the parameter in question.',
+        msg.getRequestHeader().getURI().toString(),
+        ','.join(result), '', msg.getRequestHeader().toString()+'\n'+msg.getRequestBody().toString(), '', '', 0, 0, msg);
 
-        if result:
-            ps.raiseAlert(0, 1, 'Possible File Inclusion or Path Traversal', 'HUNT located the ' + ','.join(result) + ' parameter inside of your application traffic. The ' + ','.join(result) + ' parameter is most often susceptible to File Inclusion or Path Traversal. HUNT recommends further manual analysis of the parameter in question. Also note that several parameters from this section and SSRF might overlap or need testing for both vulnerability categories.\n\nFor File Inclusion or Path Traversal HUNT recommends the following resources to aid in manual testing:\n\n- The Web Application Hackers Handbook: Chapter 10\n- LFI Cheat Sheet: https://highon.coffee/blog/lfi-cheat-sheet/ \n- Gracefuls Path Traversal Cheat Sheet: Windows: https://www.gracefulsecurity.com/path-traversal-cheat-sheet-windows/ \n- Gracefuls Path Traversal Cheat Sheet: Linux: https://www.gracefulsecurity.com/path-traversal-cheat-sheet-linux/',
-            msg.getRequestHeader().getURI().toString(),
-            ','.join(result), '', msg.getRequestHeader().toString()+'\n'+msg.getRequestBody().toString(), '', '', 0, 0, msg);
+    # Searching File Inclusion
+    result = []
+    for x in words_pfi:
+        y = re.compile(".*"+x)
+        if len(filter(y.match, params))>0:
+            result.append(x)
 
-        # Searching IDORs
-        result = []
-        for x in words_pidor:
-            y = re.compile(".*"+x)
-            if len(filter(y.match, params))>0:
-                result.append(x)
+    if result:
+        ps.raiseAlert(0, 1, 'Possible File Inclusion or Path Traversal', 'HUNT located the ' + ','.join(result) + ' parameter inside of your application traffic. The ' + ','.join(result) + ' parameter is most often susceptible to File Inclusion or Path Traversal. HUNT recommends further manual analysis of the parameter in question. Also note that several parameters from this section and SSRF might overlap or need testing for both vulnerability categories.\n\nFor File Inclusion or Path Traversal HUNT recommends the following resources to aid in manual testing:\n\n- The Web Application Hackers Handbook: Chapter 10\n- LFI Cheat Sheet: https://highon.coffee/blog/lfi-cheat-sheet/ \n- Gracefuls Path Traversal Cheat Sheet: Windows: https://www.gracefulsecurity.com/path-traversal-cheat-sheet-windows/ \n- Gracefuls Path Traversal Cheat Sheet: Linux: https://www.gracefulsecurity.com/path-traversal-cheat-sheet-linux/',
+        msg.getRequestHeader().getURI().toString(),
+        ','.join(result), '', msg.getRequestHeader().toString()+'\n'+msg.getRequestBody().toString(), '', '', 0, 0, msg);
 
-        if result:
-            ps.raiseAlert(0, 1, 'Possible IDOR', 'HUNT located the ' + ','.join(result) + ' parameter inside of your application traffic. The ' + ','.join(result) + ' parameter is most often susceptible to Insecure Direct Object Reference Vulnerabilities. \n\nDirect object reference vulnerabilities occur when there are insufficient authorization checks performed against object identifiers used in requests. This could occur when database keys, filenames, or other identifiers are used to directly access resources within an application. \nThese identifiers would likely be predictable (an incrementing counter, the name of a file, etc), making it easy for an attacker to detect this vulnerability class. If further authorization checks are not performed, this could lead to unauthorized access to the underlying data.\nHUNT recommends further manual analysis of the parameter in question.\n\nFor Insecure Direct Object Reference Vulnerabilities HUNT recommends the following resources to aid in manual testing:\n\n- The Web Application Hackers Handbook: Chapter 8\n- Testing for Insecure Direct Object References (OTG-AUTHZ-004): https://www.owasp.org/index.php/Testing_for_Insecure_Direct_Object_References_(OTG-AUTHZ-004) \n- Using Burp to Test for Insecure Direct Object References: https://support.portswigger.net/customer/portal/articles/1965691-using-burp-to-test-for-insecure-direct-object-references\n- IDOR Examples from ngalongc/bug-bounty-reference: https://github.com/ngalongc/bug-bounty-reference#insecure-direct-object-reference-idor',
-            msg.getRequestHeader().getURI().toString(),
-            ','.join(result), '', msg.getRequestHeader().toString()+'\n'+msg.getRequestBody().toString(), '', '', 0, 0, msg);
+    # Searching IDORs
+    result = []
+    for x in words_pidor:
+        y = re.compile(".*"+x)
+        if len(filter(y.match, params))>0:
+            result.append(x)
 
-        # Searching RCEs
-        result = []
-        for x in words_prce:
-            y = re.compile(".*"+x)
-            if len(filter(y.match, params))>0:
-                result.append(x)
+    if result:
+        ps.raiseAlert(0, 1, 'Possible IDOR', 'HUNT located the ' + ','.join(result) + ' parameter inside of your application traffic. The ' + ','.join(result) + ' parameter is most often susceptible to Insecure Direct Object Reference Vulnerabilities. \n\nDirect object reference vulnerabilities occur when there are insufficient authorization checks performed against object identifiers used in requests. This could occur when database keys, filenames, or other identifiers are used to directly access resources within an application. \nThese identifiers would likely be predictable (an incrementing counter, the name of a file, etc), making it easy for an attacker to detect this vulnerability class. If further authorization checks are not performed, this could lead to unauthorized access to the underlying data.\nHUNT recommends further manual analysis of the parameter in question.\n\nFor Insecure Direct Object Reference Vulnerabilities HUNT recommends the following resources to aid in manual testing:\n\n- The Web Application Hackers Handbook: Chapter 8\n- Testing for Insecure Direct Object References (OTG-AUTHZ-004): https://www.owasp.org/index.php/Testing_for_Insecure_Direct_Object_References_(OTG-AUTHZ-004) \n- Using Burp to Test for Insecure Direct Object References: https://support.portswigger.net/customer/portal/articles/1965691-using-burp-to-test-for-insecure-direct-object-references\n- IDOR Examples from ngalongc/bug-bounty-reference: https://github.com/ngalongc/bug-bounty-reference#insecure-direct-object-reference-idor',
+        msg.getRequestHeader().getURI().toString(),
+        ','.join(result), '', msg.getRequestHeader().toString()+'\n'+msg.getRequestBody().toString(), '', '', 0, 0, msg);
 
-        if result:
-            ps.raiseAlert(0, 1, 'Possible RCE', 'HUNT located the ' + ','.join(result) + ' parameter inside of your application traffic. The ' + ','.join(result) + ' parameter is most often susceptible to OS Command Injection. HUNT recommends further manual analysis of the parameter in question.\n\nFor OS Command Injection HUNT recommends the following resources to aid in manual testing:\n\n- (OWASP) Testing for OS Command Injection: https://www.owasp.org/index.php/Testing_for_Command_Injection_(OTG-INPVAL-013)\n- Joberts How To Command Injection: https://www.hackerone.com/blog/how-to-command-injections \n- Commix Command Injection Tool: https://github.com/commixproject/commix\n-The FuzzDB OS CMD Exec section: https://github.com/fuzzdb-project/fuzzdb/tree/master/attack/os-cmd-execution \n- Ferruh Mavitunas CMDi Cheat Sheet: https://ferruh.mavituna.com/unix-command-injection-cheat-sheet-oku/ \nThe Web Application Hackers Handbook: Chapter 10',
-            msg.getRequestHeader().getURI().toString(),
-            ','.join(result), '', msg.getRequestHeader().toString()+'\n'+msg.getRequestBody().toString(), '', '', 0, 0, msg);
+    # Searching RCEs
+    result = []
+    for x in words_prce:
+        y = re.compile(".*"+x)
+        if len(filter(y.match, params))>0:
+            result.append(x)
 
-        # Searching SQLi
-        result = []
-        for x in words_psql:
-            y = re.compile(".*"+x)
-            if len(filter(y.match, params))>0:
-                result.append(x)
+    if result:
+        ps.raiseAlert(0, 1, 'Possible RCE', 'HUNT located the ' + ','.join(result) + ' parameter inside of your application traffic. The ' + ','.join(result) + ' parameter is most often susceptible to OS Command Injection. HUNT recommends further manual analysis of the parameter in question.\n\nFor OS Command Injection HUNT recommends the following resources to aid in manual testing:\n\n- (OWASP) Testing for OS Command Injection: https://www.owasp.org/index.php/Testing_for_Command_Injection_(OTG-INPVAL-013)\n- Joberts How To Command Injection: https://www.hackerone.com/blog/how-to-command-injections \n- Commix Command Injection Tool: https://github.com/commixproject/commix\n-The FuzzDB OS CMD Exec section: https://github.com/fuzzdb-project/fuzzdb/tree/master/attack/os-cmd-execution \n- Ferruh Mavitunas CMDi Cheat Sheet: https://ferruh.mavituna.com/unix-command-injection-cheat-sheet-oku/ \nThe Web Application Hackers Handbook: Chapter 10',
+        msg.getRequestHeader().getURI().toString(),
+        ','.join(result), '', msg.getRequestHeader().toString()+'\n'+msg.getRequestBody().toString(), '', '', 0, 0, msg);
 
-        if result:
-            ps.raiseAlert(0, 1, 'Possible SQLi', 'HUNT located the parameter inside of your application traffic. The parameter is most often susceptible to SQL Injection. HUNT recommends further manual analysis of the parameter in question.\n\nFor SQL Injection HUNT references The Bug Hunters Methodology SQL Injection references table:\n\n- PentestMonkeys MySQL Injection Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/mysql-sql-injection-cheat-sheet \n\n- Reiners MySQL Injection Filter Evasion: https://websec.wordpress.com/2010/12/04/sqli-filter-evasion-cheat-sheet-mysql/ \n- EvilSQLs Error/Union/Blind MSSQL Cheat Sheet: http://evilsql.com/main/page2.php \n- PentestMonkeys MSSQL SQL Injection Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/mssql-sql-injection-cheat-sheet \n- PentestMonkeys Oracle SQL Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/oracle-sql-injection-cheat-sheet \n- PentestMonkeys PostgreSQL Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/postgres-sql-injection-cheat-sheet \n- Access SQL Injection Cheat Sheet: http://nibblesec.org/files/MSAccessSQLi/MSAccessSQLi.html \n- PentestMonkeys Ingres SQL Injection Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/ingres-sql-injection-cheat-sheet \n- PentestMonkeys DB2 SQL Injection Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/db2-sql-injection-cheat-sheet \n- PentestMonkeys Informix SQL Injection Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/informix-sql-injection-cheat-sheet \n- SQLite3 Injection Cheat Sheet: https://sites.google.com/site/0x7674/home/sqlite3injectioncheatsheet \n- Ruby on Rails (ActiveRecord) SQL Injection Guide: https://sites.google.com/site/0x7674/home/sqlite3injectioncheatsheet',
-            msg.getRequestHeader().getURI().toString(),
-            ','.join(result), '', msg.getRequestHeader().toString()+'\n'+msg.getRequestBody().toString(), '',
-            '', 0, 0, msg);
+    # Searching SQLi
+    result = []
+    for x in words_psql:
+        y = re.compile(".*"+x)
+        if len(filter(y.match, params))>0:
+            result.append(x)
 
-        # Searching SSRF
-        result = []
-        for x in words_pssrf:
-            y = re.compile(".*"+x)
-            if len(filter(y.match, params))>0:
-                result.append(x)
+    if result:
+        ps.raiseAlert(0, 1, 'Possible SQLi', 'HUNT located the parameter inside of your application traffic. The parameter is most often susceptible to SQL Injection. HUNT recommends further manual analysis of the parameter in question.\n\nFor SQL Injection HUNT references The Bug Hunters Methodology SQL Injection references table:\n\n- PentestMonkeys MySQL Injection Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/mysql-sql-injection-cheat-sheet \n\n- Reiners MySQL Injection Filter Evasion: https://websec.wordpress.com/2010/12/04/sqli-filter-evasion-cheat-sheet-mysql/ \n- EvilSQLs Error/Union/Blind MSSQL Cheat Sheet: http://evilsql.com/main/page2.php \n- PentestMonkeys MSSQL SQL Injection Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/mssql-sql-injection-cheat-sheet \n- PentestMonkeys Oracle SQL Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/oracle-sql-injection-cheat-sheet \n- PentestMonkeys PostgreSQL Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/postgres-sql-injection-cheat-sheet \n- Access SQL Injection Cheat Sheet: http://nibblesec.org/files/MSAccessSQLi/MSAccessSQLi.html \n- PentestMonkeys Ingres SQL Injection Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/ingres-sql-injection-cheat-sheet \n- PentestMonkeys DB2 SQL Injection Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/db2-sql-injection-cheat-sheet \n- PentestMonkeys Informix SQL Injection Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/informix-sql-injection-cheat-sheet \n- SQLite3 Injection Cheat Sheet: https://sites.google.com/site/0x7674/home/sqlite3injectioncheatsheet \n- Ruby on Rails (ActiveRecord) SQL Injection Guide: https://sites.google.com/site/0x7674/home/sqlite3injectioncheatsheet',
+        msg.getRequestHeader().getURI().toString(),
+        ','.join(result), '', msg.getRequestHeader().toString()+'\n'+msg.getRequestBody().toString(), '',
+        '', 0, 0, msg);
 
-        if result:
-            ps.raiseAlert(0, 1, 'Possible SSRF', 'HUNT located the ' + ','.join(result) + ' parameter inside of your application traffic. The ' + ','.join(result) + ' parameter is most often susceptible to Server Side Request Forgery (and sometimes URL redirects). HUNT recommends further manual analysis of the parameter in question.\n\nFor Server Side Request Forgery HUNT recommends the following resources to aid in manual testing:\n\n- Server-side browsing considered harmful - Nicolas Gregoire: http://www.agarri.fr/docs/AppSecEU15-Server_side_browsing_considered_harmful.pdf \n- How To: Server-Side Request Forgery (SSRF) - Jobert Abma: https://www.hackerone.com/blog-How-To-Server-Side-Request-Forgery-SSRF \n- SSRF Examples from ngalongc/bug-bounty-reference: https://github.com/ngalongc/bug-bounty-reference#server-side-request-forgery-ssrf \n- Safebuff SSRF Tips: http://blog.safebuff.com/2016/07/03/SSRF-Tips/ \n- The SSRF Bible: https://docs.google.com/document/d/1v1TkWZtrhzRLy0bYXBcdLUedXGb9njTNIJXa3u9akHM/edit',
-            msg.getRequestHeader().getURI().toString(),
-            ','.join(result), '', msg.getRequestHeader().toString()+'\n'+msg.getRequestBody().toString(), '', '', 0, 0, msg);
+    # Searching SSRF
+    result = []
+    for x in words_pssrf:
+        y = re.compile(".*"+x)
+        if len(filter(y.match, params))>0:
+            result.append(x)
 
-        # Searching SSTI
-        result = []
-        for x in words_pssti:
-            y = re.compile(".*"+x)
-            if len(filter(y.match, params))>0:
-                result.append(x)
+    if result:
+        ps.raiseAlert(0, 1, 'Possible SSRF', 'HUNT located the ' + ','.join(result) + ' parameter inside of your application traffic. The ' + ','.join(result) + ' parameter is most often susceptible to Server Side Request Forgery (and sometimes URL redirects). HUNT recommends further manual analysis of the parameter in question.\n\nFor Server Side Request Forgery HUNT recommends the following resources to aid in manual testing:\n\n- Server-side browsing considered harmful - Nicolas Gregoire: http://www.agarri.fr/docs/AppSecEU15-Server_side_browsing_considered_harmful.pdf \n- How To: Server-Side Request Forgery (SSRF) - Jobert Abma: https://www.hackerone.com/blog-How-To-Server-Side-Request-Forgery-SSRF \n- SSRF Examples from ngalongc/bug-bounty-reference: https://github.com/ngalongc/bug-bounty-reference#server-side-request-forgery-ssrf \n- Safebuff SSRF Tips: http://blog.safebuff.com/2016/07/03/SSRF-Tips/ \n- The SSRF Bible: https://docs.google.com/document/d/1v1TkWZtrhzRLy0bYXBcdLUedXGb9njTNIJXa3u9akHM/edit',
+        msg.getRequestHeader().getURI().toString(),
+        ','.join(result), '', msg.getRequestHeader().toString()+'\n'+msg.getRequestBody().toString(), '', '', 0, 0, msg);
 
-        if result:
-            ps.raiseAlert(0, 1, 'Possible SSTI', 'HUNT located the ' + ','.join(result) + ' parameter inside of your application traffic. The ' + ','.join(result) + ' parameter is most often susceptible to Server Side Template Injection. HUNT recommends further manual analysis of the parameter in question.',
-            msg.getRequestHeader().getURI().toString(),
-            ','.join(result), '', msg.getRequestHeader().toString()+'\n'+msg.getRequestBody().toString(), '', '', 0, 0, msg);
+    # Searching SSTI
+    result = []
+    for x in words_pssti:
+        y = re.compile(".*"+x)
+        if len(filter(y.match, params))>0:
+            result.append(x)
+
+    if result:
+        ps.raiseAlert(0, 1, 'Possible SSTI', 'HUNT located the ' + ','.join(result) + ' parameter inside of your application traffic. The ' + ','.join(result) + ' parameter is most often susceptible to Server Side Template Injection. HUNT recommends further manual analysis of the parameter in question.',
+        msg.getRequestHeader().getURI().toString(),
+        ','.join(result), '', msg.getRequestHeader().toString()+'\n'+msg.getRequestBody().toString(), '', '', 0, 0, msg);

--- a/passive/HUNT.py
+++ b/passive/HUNT.py
@@ -23,6 +23,26 @@ def find_words_in_params(param_list, word_list):
     return result
 
 
+def hunt_alert(ps, msg, uri, result, title, desc):
+    if not result:
+        return
+
+    result_repr = ','.join(result)
+    desc = desc.strip().format(result=result_repr)
+
+    info = msg.getRequestHeader().toString()
+    info += "\n" + msg.getRequestBody().toString()
+
+    # Docs on alert raising function:
+    #  raiseAlert(int risk, int confidence, str name, str description, str uri,
+    #             str param, str attack, str otherInfo, str solution,
+    #             str evidence, int cweId, int wascId, HttpMessage msg)
+    #  risk: 0: info, 1: low, 2: medium, 3: high
+    #  confidence: 0: falsePositive, 1: low, 2: medium, 3: high, 4: confirmed
+    ps.raiseAlert(0, 1, title, desc, uri, result_repr,
+            None, info, None, None, 0, 0, msg)
+
+
 def scan(ps, msg, src):
     words_dlp = ['access','admin','dbg','debug','edit','grant','test','alter','clone','create','delete','disable','enable','exec','execute','load','make','modify','rename','reset','shell','toggle','adm','root','cfg','config']
     words_pfi = ['file','document','folder','root','path','pg','style','pdf','template','php_path','doc']
@@ -51,50 +71,167 @@ def scan(ps, msg, src):
 
     # Searching Debug and Logic
     result = find_words_in_params(params, words_dlp)
-    if result:
-        ps.raiseAlert(0, 1, 'Possible Debug & Logic Parameters', 'HUNT located the' + ','.join(result) + ' parameter inside of your application traffic. The ' + ','.join(result) + ' parameter is most often associated to debug,  access, or critical functionality in applications. \nHUNT recommends further manual analysis of the parameter in question.',
-        msg.getRequestHeader().getURI().toString(),
-        ','.join(result), '', msg.getRequestHeader().toString()+'\n'+msg.getRequestBody().toString(), '', '', 0, 0, msg);
+    hunt_alert(ps, msg, uri, result,
+    "Possible Debug & Logic Parameters", """
+HUNT located the {result} parameter inside of your application traffic. \
+The {result} parameter is most often associated to debug, access, or \
+critical functionality in applications.
+
+HUNT recommends further manual analysis of the parameter in question.
+""")
 
     # Searching File Inclusion
     result = find_words_in_params(params, words_pfi)
-    if result:
-        ps.raiseAlert(0, 1, 'Possible File Inclusion or Path Traversal', 'HUNT located the ' + ','.join(result) + ' parameter inside of your application traffic. The ' + ','.join(result) + ' parameter is most often susceptible to File Inclusion or Path Traversal. HUNT recommends further manual analysis of the parameter in question. Also note that several parameters from this section and SSRF might overlap or need testing for both vulnerability categories.\n\nFor File Inclusion or Path Traversal HUNT recommends the following resources to aid in manual testing:\n\n- The Web Application Hackers Handbook: Chapter 10\n- LFI Cheat Sheet: https://highon.coffee/blog/lfi-cheat-sheet/ \n- Gracefuls Path Traversal Cheat Sheet: Windows: https://www.gracefulsecurity.com/path-traversal-cheat-sheet-windows/ \n- Gracefuls Path Traversal Cheat Sheet: Linux: https://www.gracefulsecurity.com/path-traversal-cheat-sheet-linux/',
-        msg.getRequestHeader().getURI().toString(),
-        ','.join(result), '', msg.getRequestHeader().toString()+'\n'+msg.getRequestBody().toString(), '', '', 0, 0, msg);
+    hunt_alert(ps, msg, uri, result,
+    "Possible File Inclusion or Path Traversal", """
+HUNT located the {result} parameter inside of your application traffic. \
+The {result} parameter is most often susceptible to \
+File Inclusion or Path Traversal.
+
+HUNT recommends further manual analysis of the parameter in question.
+
+Also note that several parameters from this section and SSRF might overlap or \
+need testing for both vulnerability categories.
+
+For File Inclusion or Path Traversal HUNT recommends the following resources \
+to aid in manual testing:
+
+- The Web Application Hackers Handbook: \
+Chapter 10
+- LFI Cheat Sheet: https://highon.coffee/blog/lfi-cheat-sheet/
+- Gracefuls Path Traversal Cheat Sheet: Windows: \
+https://www.gracefulsecurity.com/path-traversal-cheat-sheet-windows/
+- Gracefuls Path Traversal Cheat Sheet: Linux: \
+https://www.gracefulsecurity.com/path-traversal-cheat-sheet-linux/
+""")
 
     # Searching IDORs
     result = find_words_in_params(params, words_pidor)
-    if result:
-        ps.raiseAlert(0, 1, 'Possible IDOR', 'HUNT located the ' + ','.join(result) + ' parameter inside of your application traffic. The ' + ','.join(result) + ' parameter is most often susceptible to Insecure Direct Object Reference Vulnerabilities. \n\nDirect object reference vulnerabilities occur when there are insufficient authorization checks performed against object identifiers used in requests. This could occur when database keys, filenames, or other identifiers are used to directly access resources within an application. \nThese identifiers would likely be predictable (an incrementing counter, the name of a file, etc), making it easy for an attacker to detect this vulnerability class. If further authorization checks are not performed, this could lead to unauthorized access to the underlying data.\nHUNT recommends further manual analysis of the parameter in question.\n\nFor Insecure Direct Object Reference Vulnerabilities HUNT recommends the following resources to aid in manual testing:\n\n- The Web Application Hackers Handbook: Chapter 8\n- Testing for Insecure Direct Object References (OTG-AUTHZ-004): https://www.owasp.org/index.php/Testing_for_Insecure_Direct_Object_References_(OTG-AUTHZ-004) \n- Using Burp to Test for Insecure Direct Object References: https://support.portswigger.net/customer/portal/articles/1965691-using-burp-to-test-for-insecure-direct-object-references\n- IDOR Examples from ngalongc/bug-bounty-reference: https://github.com/ngalongc/bug-bounty-reference#insecure-direct-object-reference-idor',
-        msg.getRequestHeader().getURI().toString(),
-        ','.join(result), '', msg.getRequestHeader().toString()+'\n'+msg.getRequestBody().toString(), '', '', 0, 0, msg);
+    hunt_alert(ps, msg, uri, result,
+    "Possible IDOR", """
+HUNT located the {result} parameter inside of your application traffic. \
+The {result} parameter is most often susceptible to \
+Insecure Direct Object Reference Vulnerabilities.
+
+Direct object reference vulnerabilities occur when there are insufficient \
+authorization checks performed against object identifiers used in requests. \
+This could occur when database keys, filenames, or other identifiers are used \
+to directly access resources within an application.
+These identifiers would likely be predictable (an incrementing counter, \
+the name of a file, etc), making it easy for an attacker to detect this \
+vulnerability class. If further authorization checks are not performed, this \
+could lead to unauthorized access to the underlying data.
+
+HUNT recommends further manual analysis of the parameter in question.
+
+For Insecure Direct Object Reference Vulnerabilities HUNT recommends the \
+following resources to aid in manual testing:
+
+- The Web Application Hackers Handbook: \
+Chapter 8
+- Testing for Insecure Direct Object References (OTG-AUTHZ-004): \
+https://www.owasp.org/index.php/Testing_for_Insecure_Direct_Object_References_(OTG-AUTHZ-004)
+- Using Burp to Test for Insecure Direct Object References: \
+https://support.portswigger.net/customer/portal/articles/1965691-using-burp-to-test-for-insecure-direct-object-references
+- IDOR Examples from ngalongc/bug-bounty-reference: \
+https://github.com/ngalongc/bug-bounty-reference#insecure-direct-object-reference-idor
+""")
 
     # Searching RCEs
     result = find_words_in_params(params, words_prce)
-    if result:
-        ps.raiseAlert(0, 1, 'Possible RCE', 'HUNT located the ' + ','.join(result) + ' parameter inside of your application traffic. The ' + ','.join(result) + ' parameter is most often susceptible to OS Command Injection. HUNT recommends further manual analysis of the parameter in question.\n\nFor OS Command Injection HUNT recommends the following resources to aid in manual testing:\n\n- (OWASP) Testing for OS Command Injection: https://www.owasp.org/index.php/Testing_for_Command_Injection_(OTG-INPVAL-013)\n- Joberts How To Command Injection: https://www.hackerone.com/blog/how-to-command-injections \n- Commix Command Injection Tool: https://github.com/commixproject/commix\n-The FuzzDB OS CMD Exec section: https://github.com/fuzzdb-project/fuzzdb/tree/master/attack/os-cmd-execution \n- Ferruh Mavitunas CMDi Cheat Sheet: https://ferruh.mavituna.com/unix-command-injection-cheat-sheet-oku/ \nThe Web Application Hackers Handbook: Chapter 10',
-        msg.getRequestHeader().getURI().toString(),
-        ','.join(result), '', msg.getRequestHeader().toString()+'\n'+msg.getRequestBody().toString(), '', '', 0, 0, msg);
+    hunt_alert(ps, msg, uri, result,
+    "Possible RCE", """
+HUNT located the {result} parameter inside of your application traffic. \
+The {result} parameter is most often susceptible to OS Command Injection.
+
+HUNT recommends further manual analysis of the parameter in question.
+
+For OS Command Injection HUNT recommends the following resources to aid \
+in manual testing:
+
+- (OWASP) Testing for OS Command Injection: \
+https://www.owasp.org/index.php/Testing_for_Command_Injection_(OTG-INPVAL-013)
+- Joberts How To Command Injection: \
+https://www.hackerone.com/blog/how-to-command-injections
+- Commix Command Injection Tool: \
+https://github.com/commixproject/commix
+-The FuzzDB OS CMD Exec section: \
+https://github.com/fuzzdb-project/fuzzdb/tree/master/attack/os-cmd-execution
+- Ferruh Mavitunas CMDi Cheat Sheet: \
+https://ferruh.mavituna.com/unix-command-injection-cheat-sheet-oku/
+- The Web Application Hackers Handbook: Chapter 10
+""")
 
     # Searching SQLi
     result = find_words_in_params(params, words_psql)
-    if result:
-        ps.raiseAlert(0, 1, 'Possible SQLi', 'HUNT located the parameter inside of your application traffic. The parameter is most often susceptible to SQL Injection. HUNT recommends further manual analysis of the parameter in question.\n\nFor SQL Injection HUNT references The Bug Hunters Methodology SQL Injection references table:\n\n- PentestMonkeys MySQL Injection Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/mysql-sql-injection-cheat-sheet \n\n- Reiners MySQL Injection Filter Evasion: https://websec.wordpress.com/2010/12/04/sqli-filter-evasion-cheat-sheet-mysql/ \n- EvilSQLs Error/Union/Blind MSSQL Cheat Sheet: http://evilsql.com/main/page2.php \n- PentestMonkeys MSSQL SQL Injection Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/mssql-sql-injection-cheat-sheet \n- PentestMonkeys Oracle SQL Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/oracle-sql-injection-cheat-sheet \n- PentestMonkeys PostgreSQL Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/postgres-sql-injection-cheat-sheet \n- Access SQL Injection Cheat Sheet: http://nibblesec.org/files/MSAccessSQLi/MSAccessSQLi.html \n- PentestMonkeys Ingres SQL Injection Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/ingres-sql-injection-cheat-sheet \n- PentestMonkeys DB2 SQL Injection Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/db2-sql-injection-cheat-sheet \n- PentestMonkeys Informix SQL Injection Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/informix-sql-injection-cheat-sheet \n- SQLite3 Injection Cheat Sheet: https://sites.google.com/site/0x7674/home/sqlite3injectioncheatsheet \n- Ruby on Rails (ActiveRecord) SQL Injection Guide: https://sites.google.com/site/0x7674/home/sqlite3injectioncheatsheet',
-        msg.getRequestHeader().getURI().toString(),
-        ','.join(result), '', msg.getRequestHeader().toString()+'\n'+msg.getRequestBody().toString(), '',
-        '', 0, 0, msg);
+    hunt_alert(ps, msg, uri, result,
+    "Possible SQLi", """
+HUNT located the {result} parameter inside of your application traffic. \
+The {result} parameter is most often susceptible to SQL Injection.
+
+HUNT recommends further manual analysis of the parameter in question.
+
+For SQL Injection HUNT references The Bug Hunters Methodology \
+SQL Injection references table:
+
+- PentestMonkeys MySQL Injection Cheat Sheet: \
+http://pentestmonkey.net/cheat-sheet/sql-injection/mysql-sql-injection-cheat-sheet
+- Reiners MySQL Injection Filter Evasion: \
+https://websec.wordpress.com/2010/12/04/sqli-filter-evasion-cheat-sheet-mysql/
+- EvilSQLs Error/Union/Blind MSSQL Cheat Sheet: \
+http://evilsql.com/main/page2.php
+- PentestMonkeys MSSQL SQL Injection Cheat Sheet: \
+http://pentestmonkey.net/cheat-sheet/sql-injection/mssql-sql-injection-cheat-sheet
+- PentestMonkeys Oracle SQL Cheat Sheet: \
+http://pentestmonkey.net/cheat-sheet/sql-injection/oracle-sql-injection-cheat-sheet
+- PentestMonkeys PostgreSQL Cheat Sheet: \
+http://pentestmonkey.net/cheat-sheet/sql-injection/postgres-sql-injection-cheat-sheet
+- Access SQL Injection Cheat Sheet: \
+http://nibblesec.org/files/MSAccessSQLi/MSAccessSQLi.html
+- PentestMonkeys Ingres SQL Injection Cheat Sheet: \
+http://pentestmonkey.net/cheat-sheet/sql-injection/ingres-sql-injection-cheat-sheet
+- PentestMonkeys DB2 SQL Injection Cheat Sheet: \
+http://pentestmonkey.net/cheat-sheet/sql-injection/db2-sql-injection-cheat-sheet
+- PentestMonkeys Informix SQL Injection Cheat Sheet: \
+http://pentestmonkey.net/cheat-sheet/sql-injection/informix-sql-injection-cheat-sheet
+- SQLite3 Injection Cheat Sheet: \
+https://sites.google.com/site/0x7674/home/sqlite3injectioncheatsheet
+- Ruby on Rails (ActiveRecord) SQL Injection Guide: \
+https://sites.google.com/site/0x7674/home/sqlite3injectioncheatsheet
+""")
 
     # Searching SSRF
     result = find_words_in_params(params, words_pssrf)
-    if result:
-        ps.raiseAlert(0, 1, 'Possible SSRF', 'HUNT located the ' + ','.join(result) + ' parameter inside of your application traffic. The ' + ','.join(result) + ' parameter is most often susceptible to Server Side Request Forgery (and sometimes URL redirects). HUNT recommends further manual analysis of the parameter in question.\n\nFor Server Side Request Forgery HUNT recommends the following resources to aid in manual testing:\n\n- Server-side browsing considered harmful - Nicolas Gregoire: http://www.agarri.fr/docs/AppSecEU15-Server_side_browsing_considered_harmful.pdf \n- How To: Server-Side Request Forgery (SSRF) - Jobert Abma: https://www.hackerone.com/blog-How-To-Server-Side-Request-Forgery-SSRF \n- SSRF Examples from ngalongc/bug-bounty-reference: https://github.com/ngalongc/bug-bounty-reference#server-side-request-forgery-ssrf \n- Safebuff SSRF Tips: http://blog.safebuff.com/2016/07/03/SSRF-Tips/ \n- The SSRF Bible: https://docs.google.com/document/d/1v1TkWZtrhzRLy0bYXBcdLUedXGb9njTNIJXa3u9akHM/edit',
-        msg.getRequestHeader().getURI().toString(),
-        ','.join(result), '', msg.getRequestHeader().toString()+'\n'+msg.getRequestBody().toString(), '', '', 0, 0, msg);
+    hunt_alert(ps, msg, uri, result,
+    "Possible SSRF", """
+HUNT located the {result} parameter inside of your application traffic. \
+The {result} parameter is most often susceptible to \
+Server Side Request Forgery (and sometimes URL redirects).
+
+HUNT recommends further manual analysis of the parameter in question.
+
+For Server Side Request Forgery HUNT recommends the following resources to \
+aid in manual testing:
+
+- Server-side browsing considered harmful - Nicolas Gregoire: \
+http://www.agarri.fr/docs/AppSecEU15-Server_side_browsing_considered_harmful.pdf
+- How To: Server-Side Request Forgery (SSRF) - Jobert Abma: \
+https://www.hackerone.com/blog-How-To-Server-Side-Request-Forgery-SSRF
+- SSRF Examples from ngalongc/bug-bounty-reference: \
+https://github.com/ngalongc/bug-bounty-reference#server-side-request-forgery-ssrf
+- Safebuff SSRF Tips: \
+http://blog.safebuff.com/2016/07/03/SSRF-Tips/
+- The SSRF Bible: \
+https://docs.google.com/document/d/1v1TkWZtrhzRLy0bYXBcdLUedXGb9njTNIJXa3u9akHM/edit
+""")
 
     # Searching SSTI
     result = find_words_in_params(params, words_pssti)
-    if result:
-        ps.raiseAlert(0, 1, 'Possible SSTI', 'HUNT located the ' + ','.join(result) + ' parameter inside of your application traffic. The ' + ','.join(result) + ' parameter is most often susceptible to Server Side Template Injection. HUNT recommends further manual analysis of the parameter in question.',
-        msg.getRequestHeader().getURI().toString(),
-        ','.join(result), '', msg.getRequestHeader().toString()+'\n'+msg.getRequestBody().toString(), '', '', 0, 0, msg);
+    hunt_alert(ps, msg, uri, result,
+    "Possible SSTI", """
+HUNT located the {result} parameter inside of your application traffic. \
+The {result} parameter is most often susceptible to \
+Server Side Template Injection.
+
+HUNT recommends further manual analysis of the parameter in question.
+""")

--- a/passive/HUNT.py
+++ b/passive/HUNT.py
@@ -14,6 +14,15 @@ def appliesToHistoryType(histType):
     return histType in [hr.TYPE_PROXIED, hr.TYPE_SPIDER]
 
 
+def find_words_in_params(param_list, word_list):
+    result = []
+    for word in word_list:
+        for param in param_list:
+            if word in param:
+                result.append(word)
+    return result
+
+
 def scan(ps, msg, src):
     words_dlp = ['access','admin','dbg','debug','edit','grant','test','alter','clone','create','delete','disable','enable','exec','execute','load','make','modify','rename','reset','shell','toggle','adm','root','cfg','config']
     words_pfi = ['file','document','folder','root','path','pg','style','pdf','template','php_path','doc']
@@ -41,60 +50,35 @@ def scan(ps, msg, src):
     ScriptVars.setGlobalVar("hunt", globalvar + ' , ' + urlParam_repr)
 
     # Searching Debug and Logic
-    result = []
-    for x in words_dlp:
-        y = re.compile(".*"+x)
-        if len(filter(y.match, params))>0:
-            result.append(x)
-
+    result = find_words_in_params(params, words_dlp)
     if result:
         ps.raiseAlert(0, 1, 'Possible Debug & Logic Parameters', 'HUNT located the' + ','.join(result) + ' parameter inside of your application traffic. The ' + ','.join(result) + ' parameter is most often associated to debug,  access, or critical functionality in applications. \nHUNT recommends further manual analysis of the parameter in question.',
         msg.getRequestHeader().getURI().toString(),
         ','.join(result), '', msg.getRequestHeader().toString()+'\n'+msg.getRequestBody().toString(), '', '', 0, 0, msg);
 
     # Searching File Inclusion
-    result = []
-    for x in words_pfi:
-        y = re.compile(".*"+x)
-        if len(filter(y.match, params))>0:
-            result.append(x)
-
+    result = find_words_in_params(params, words_pfi)
     if result:
         ps.raiseAlert(0, 1, 'Possible File Inclusion or Path Traversal', 'HUNT located the ' + ','.join(result) + ' parameter inside of your application traffic. The ' + ','.join(result) + ' parameter is most often susceptible to File Inclusion or Path Traversal. HUNT recommends further manual analysis of the parameter in question. Also note that several parameters from this section and SSRF might overlap or need testing for both vulnerability categories.\n\nFor File Inclusion or Path Traversal HUNT recommends the following resources to aid in manual testing:\n\n- The Web Application Hackers Handbook: Chapter 10\n- LFI Cheat Sheet: https://highon.coffee/blog/lfi-cheat-sheet/ \n- Gracefuls Path Traversal Cheat Sheet: Windows: https://www.gracefulsecurity.com/path-traversal-cheat-sheet-windows/ \n- Gracefuls Path Traversal Cheat Sheet: Linux: https://www.gracefulsecurity.com/path-traversal-cheat-sheet-linux/',
         msg.getRequestHeader().getURI().toString(),
         ','.join(result), '', msg.getRequestHeader().toString()+'\n'+msg.getRequestBody().toString(), '', '', 0, 0, msg);
 
     # Searching IDORs
-    result = []
-    for x in words_pidor:
-        y = re.compile(".*"+x)
-        if len(filter(y.match, params))>0:
-            result.append(x)
-
+    result = find_words_in_params(params, words_pidor)
     if result:
         ps.raiseAlert(0, 1, 'Possible IDOR', 'HUNT located the ' + ','.join(result) + ' parameter inside of your application traffic. The ' + ','.join(result) + ' parameter is most often susceptible to Insecure Direct Object Reference Vulnerabilities. \n\nDirect object reference vulnerabilities occur when there are insufficient authorization checks performed against object identifiers used in requests. This could occur when database keys, filenames, or other identifiers are used to directly access resources within an application. \nThese identifiers would likely be predictable (an incrementing counter, the name of a file, etc), making it easy for an attacker to detect this vulnerability class. If further authorization checks are not performed, this could lead to unauthorized access to the underlying data.\nHUNT recommends further manual analysis of the parameter in question.\n\nFor Insecure Direct Object Reference Vulnerabilities HUNT recommends the following resources to aid in manual testing:\n\n- The Web Application Hackers Handbook: Chapter 8\n- Testing for Insecure Direct Object References (OTG-AUTHZ-004): https://www.owasp.org/index.php/Testing_for_Insecure_Direct_Object_References_(OTG-AUTHZ-004) \n- Using Burp to Test for Insecure Direct Object References: https://support.portswigger.net/customer/portal/articles/1965691-using-burp-to-test-for-insecure-direct-object-references\n- IDOR Examples from ngalongc/bug-bounty-reference: https://github.com/ngalongc/bug-bounty-reference#insecure-direct-object-reference-idor',
         msg.getRequestHeader().getURI().toString(),
         ','.join(result), '', msg.getRequestHeader().toString()+'\n'+msg.getRequestBody().toString(), '', '', 0, 0, msg);
 
     # Searching RCEs
-    result = []
-    for x in words_prce:
-        y = re.compile(".*"+x)
-        if len(filter(y.match, params))>0:
-            result.append(x)
-
+    result = find_words_in_params(params, words_prce)
     if result:
         ps.raiseAlert(0, 1, 'Possible RCE', 'HUNT located the ' + ','.join(result) + ' parameter inside of your application traffic. The ' + ','.join(result) + ' parameter is most often susceptible to OS Command Injection. HUNT recommends further manual analysis of the parameter in question.\n\nFor OS Command Injection HUNT recommends the following resources to aid in manual testing:\n\n- (OWASP) Testing for OS Command Injection: https://www.owasp.org/index.php/Testing_for_Command_Injection_(OTG-INPVAL-013)\n- Joberts How To Command Injection: https://www.hackerone.com/blog/how-to-command-injections \n- Commix Command Injection Tool: https://github.com/commixproject/commix\n-The FuzzDB OS CMD Exec section: https://github.com/fuzzdb-project/fuzzdb/tree/master/attack/os-cmd-execution \n- Ferruh Mavitunas CMDi Cheat Sheet: https://ferruh.mavituna.com/unix-command-injection-cheat-sheet-oku/ \nThe Web Application Hackers Handbook: Chapter 10',
         msg.getRequestHeader().getURI().toString(),
         ','.join(result), '', msg.getRequestHeader().toString()+'\n'+msg.getRequestBody().toString(), '', '', 0, 0, msg);
 
     # Searching SQLi
-    result = []
-    for x in words_psql:
-        y = re.compile(".*"+x)
-        if len(filter(y.match, params))>0:
-            result.append(x)
-
+    result = find_words_in_params(params, words_psql)
     if result:
         ps.raiseAlert(0, 1, 'Possible SQLi', 'HUNT located the parameter inside of your application traffic. The parameter is most often susceptible to SQL Injection. HUNT recommends further manual analysis of the parameter in question.\n\nFor SQL Injection HUNT references The Bug Hunters Methodology SQL Injection references table:\n\n- PentestMonkeys MySQL Injection Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/mysql-sql-injection-cheat-sheet \n\n- Reiners MySQL Injection Filter Evasion: https://websec.wordpress.com/2010/12/04/sqli-filter-evasion-cheat-sheet-mysql/ \n- EvilSQLs Error/Union/Blind MSSQL Cheat Sheet: http://evilsql.com/main/page2.php \n- PentestMonkeys MSSQL SQL Injection Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/mssql-sql-injection-cheat-sheet \n- PentestMonkeys Oracle SQL Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/oracle-sql-injection-cheat-sheet \n- PentestMonkeys PostgreSQL Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/postgres-sql-injection-cheat-sheet \n- Access SQL Injection Cheat Sheet: http://nibblesec.org/files/MSAccessSQLi/MSAccessSQLi.html \n- PentestMonkeys Ingres SQL Injection Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/ingres-sql-injection-cheat-sheet \n- PentestMonkeys DB2 SQL Injection Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/db2-sql-injection-cheat-sheet \n- PentestMonkeys Informix SQL Injection Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/informix-sql-injection-cheat-sheet \n- SQLite3 Injection Cheat Sheet: https://sites.google.com/site/0x7674/home/sqlite3injectioncheatsheet \n- Ruby on Rails (ActiveRecord) SQL Injection Guide: https://sites.google.com/site/0x7674/home/sqlite3injectioncheatsheet',
         msg.getRequestHeader().getURI().toString(),
@@ -102,24 +86,14 @@ def scan(ps, msg, src):
         '', 0, 0, msg);
 
     # Searching SSRF
-    result = []
-    for x in words_pssrf:
-        y = re.compile(".*"+x)
-        if len(filter(y.match, params))>0:
-            result.append(x)
-
+    result = find_words_in_params(params, words_pssrf)
     if result:
         ps.raiseAlert(0, 1, 'Possible SSRF', 'HUNT located the ' + ','.join(result) + ' parameter inside of your application traffic. The ' + ','.join(result) + ' parameter is most often susceptible to Server Side Request Forgery (and sometimes URL redirects). HUNT recommends further manual analysis of the parameter in question.\n\nFor Server Side Request Forgery HUNT recommends the following resources to aid in manual testing:\n\n- Server-side browsing considered harmful - Nicolas Gregoire: http://www.agarri.fr/docs/AppSecEU15-Server_side_browsing_considered_harmful.pdf \n- How To: Server-Side Request Forgery (SSRF) - Jobert Abma: https://www.hackerone.com/blog-How-To-Server-Side-Request-Forgery-SSRF \n- SSRF Examples from ngalongc/bug-bounty-reference: https://github.com/ngalongc/bug-bounty-reference#server-side-request-forgery-ssrf \n- Safebuff SSRF Tips: http://blog.safebuff.com/2016/07/03/SSRF-Tips/ \n- The SSRF Bible: https://docs.google.com/document/d/1v1TkWZtrhzRLy0bYXBcdLUedXGb9njTNIJXa3u9akHM/edit',
         msg.getRequestHeader().getURI().toString(),
         ','.join(result), '', msg.getRequestHeader().toString()+'\n'+msg.getRequestBody().toString(), '', '', 0, 0, msg);
 
     # Searching SSTI
-    result = []
-    for x in words_pssti:
-        y = re.compile(".*"+x)
-        if len(filter(y.match, params))>0:
-            result.append(x)
-
+    result = find_words_in_params(params, words_pssti)
     if result:
         ps.raiseAlert(0, 1, 'Possible SSTI', 'HUNT located the ' + ','.join(result) + ' parameter inside of your application traffic. The ' + ','.join(result) + ' parameter is most often susceptible to Server Side Template Injection. HUNT recommends further manual analysis of the parameter in question.',
         msg.getRequestHeader().getURI().toString(),

--- a/passive/HUNT.py
+++ b/passive/HUNT.py
@@ -3,11 +3,16 @@ from org.zaproxy.zap.extension.script import ScriptVars
 
 ''' find possible vulnerable entry points using Hunt Methodology - https://github.com/bugcrowd/HUNT'''
 
+
 def appliesToHistoryType(histType):
-    if (histType<=2):
-        return True
-    else:
-        return False
+    """
+    Limit scanned history types, which otherwise default to
+    types in `PluginPassiveScanner.getDefaultHistoryTypes()`
+    """
+    from org.parosproxy.paros.model import HistoryReference as hr
+
+    return histType in [hr.TYPE_PROXIED, hr.TYPE_SPIDER]
+
 
 def scan(ps, msg, src):
     if ScriptVars.getGlobalVar("hunt") is None:

--- a/passive/HUNT.py
+++ b/passive/HUNT.py
@@ -1,7 +1,7 @@
 import re
 from org.zaproxy.zap.extension.script import ScriptVars
 
-''' find possible vulnerable entry points using Hunt Methodology - https://github.com/bugcrowd/HUNT'''
+'''find possible vulnerable entry points using Hunt Methodology - https://github.com/bugcrowd/HUNT'''
 
 
 def appliesToHistoryType(histType):
@@ -28,6 +28,7 @@ def hunt_alert(ps, msg, uri, result, title, desc):
         return
 
     result_repr = ','.join(result)
+    title += " (HUNT script)"
     desc = desc.strip().format(result=result_repr)
 
     info = msg.getRequestHeader().toString()

--- a/passive/HUNT.py
+++ b/passive/HUNT.py
@@ -29,7 +29,7 @@ def scan(ps, msg, src):
     params = msg.getParamNames()
     params = [element.lower() for element in params]
 
-    base_uri = re.search('https?:\/\/([^/]+)(\/[^?#=]*)',uri)
+    base_uri = re.search('^https?://[^/]+/[^?#=]*', uri)
 
     if base_uri:
         base_uri = str( base_uri.group() )

--- a/passive/HUNT.py
+++ b/passive/HUNT.py
@@ -25,12 +25,13 @@ def scan(ps, msg, src):
     words_psql = ['id','select','report','role','update','query','user','name','sort','where','search','params','process','row','view','table','from','sel','results','sleep','fetch','order','keyword','column','field','delete','string','number','filter']
     words_pssrf = ['dest','redirect','uri','path','continue','url','window','next','data','reference','site','html','val','validate','domain','callback','return','page','feed','host','port','to','out','view','dir','show','navigation','open']
     words_pssti = ['template','preview','id','view','activity','name','content','redirect']
+
     uri = msg.getRequestHeader().getURI().toString()
-    params = msg.getParamNames()
-    params = [element.lower() for element in params]
+    params = [p.lower() for p in msg.getParamNames()]
 
     base_uri = re.search('^https?://[^/]+/[^?#=]*', uri)
-    if not base_uri:
+
+    if not params or not base_uri:
         return
 
     base_uri = str( base_uri.group() )

--- a/passive/HUNT.py
+++ b/passive/HUNT.py
@@ -30,96 +30,97 @@ def scan(ps, msg, src):
     params = [element.lower() for element in params]
 
     base_uri = re.search('^https?://[^/]+/[^?#=]*', uri)
+    if not base_uri:
+        return
 
-    if base_uri:
-        base_uri = str( base_uri.group() )
-        regex = base_uri + str(params)
-        globalvar = ScriptVars.getGlobalVar("hunt")
+    base_uri = str( base_uri.group() )
+    regex = base_uri + str(params)
+    globalvar = ScriptVars.getGlobalVar("hunt")
 
-        if regex not in globalvar:
-            ScriptVars.setGlobalVar("hunt","" + globalvar + ' , ' + regex)
+    if regex not in globalvar:
+        ScriptVars.setGlobalVar("hunt","" + globalvar + ' , ' + regex)
 
-            # Searching Debug and Logic
-            result = []
-            for x in words_dlp:
-                y = re.compile(".*"+x)
-                if len(filter(y.match, params))>0:
-                    result.append(x)
+        # Searching Debug and Logic
+        result = []
+        for x in words_dlp:
+            y = re.compile(".*"+x)
+            if len(filter(y.match, params))>0:
+                result.append(x)
 
-            if result:
-                ps.raiseAlert(0, 1, 'Possible Debug & Logic Parameters', 'HUNT located the' + ','.join(result) + ' parameter inside of your application traffic. The ' + ','.join(result) + ' parameter is most often associated to debug,  access, or critical functionality in applications. \nHUNT recommends further manual analysis of the parameter in question.',
-                msg.getRequestHeader().getURI().toString(),
-                ','.join(result), '', msg.getRequestHeader().toString()+'\n'+msg.getRequestBody().toString(), '', '', 0, 0, msg);
+        if result:
+            ps.raiseAlert(0, 1, 'Possible Debug & Logic Parameters', 'HUNT located the' + ','.join(result) + ' parameter inside of your application traffic. The ' + ','.join(result) + ' parameter is most often associated to debug,  access, or critical functionality in applications. \nHUNT recommends further manual analysis of the parameter in question.',
+            msg.getRequestHeader().getURI().toString(),
+            ','.join(result), '', msg.getRequestHeader().toString()+'\n'+msg.getRequestBody().toString(), '', '', 0, 0, msg);
 
-            # Searching File Inclusion
-            result = []
-            for x in words_pfi:
-                y = re.compile(".*"+x)
-                if len(filter(y.match, params))>0:
-                    result.append(x)
+        # Searching File Inclusion
+        result = []
+        for x in words_pfi:
+            y = re.compile(".*"+x)
+            if len(filter(y.match, params))>0:
+                result.append(x)
 
-            if result:
-                ps.raiseAlert(0, 1, 'Possible File Inclusion or Path Traversal', 'HUNT located the ' + ','.join(result) + ' parameter inside of your application traffic. The ' + ','.join(result) + ' parameter is most often susceptible to File Inclusion or Path Traversal. HUNT recommends further manual analysis of the parameter in question. Also note that several parameters from this section and SSRF might overlap or need testing for both vulnerability categories.\n\nFor File Inclusion or Path Traversal HUNT recommends the following resources to aid in manual testing:\n\n- The Web Application Hackers Handbook: Chapter 10\n- LFI Cheat Sheet: https://highon.coffee/blog/lfi-cheat-sheet/ \n- Gracefuls Path Traversal Cheat Sheet: Windows: https://www.gracefulsecurity.com/path-traversal-cheat-sheet-windows/ \n- Gracefuls Path Traversal Cheat Sheet: Linux: https://www.gracefulsecurity.com/path-traversal-cheat-sheet-linux/',
-                msg.getRequestHeader().getURI().toString(),
-                ','.join(result), '', msg.getRequestHeader().toString()+'\n'+msg.getRequestBody().toString(), '', '', 0, 0, msg);
+        if result:
+            ps.raiseAlert(0, 1, 'Possible File Inclusion or Path Traversal', 'HUNT located the ' + ','.join(result) + ' parameter inside of your application traffic. The ' + ','.join(result) + ' parameter is most often susceptible to File Inclusion or Path Traversal. HUNT recommends further manual analysis of the parameter in question. Also note that several parameters from this section and SSRF might overlap or need testing for both vulnerability categories.\n\nFor File Inclusion or Path Traversal HUNT recommends the following resources to aid in manual testing:\n\n- The Web Application Hackers Handbook: Chapter 10\n- LFI Cheat Sheet: https://highon.coffee/blog/lfi-cheat-sheet/ \n- Gracefuls Path Traversal Cheat Sheet: Windows: https://www.gracefulsecurity.com/path-traversal-cheat-sheet-windows/ \n- Gracefuls Path Traversal Cheat Sheet: Linux: https://www.gracefulsecurity.com/path-traversal-cheat-sheet-linux/',
+            msg.getRequestHeader().getURI().toString(),
+            ','.join(result), '', msg.getRequestHeader().toString()+'\n'+msg.getRequestBody().toString(), '', '', 0, 0, msg);
 
-            # Searching IDORs
-            result = []
-            for x in words_pidor:
-                y = re.compile(".*"+x)
-                if len(filter(y.match, params))>0:
-                    result.append(x)
+        # Searching IDORs
+        result = []
+        for x in words_pidor:
+            y = re.compile(".*"+x)
+            if len(filter(y.match, params))>0:
+                result.append(x)
 
-            if result:
-                ps.raiseAlert(0, 1, 'Possible IDOR', 'HUNT located the ' + ','.join(result) + ' parameter inside of your application traffic. The ' + ','.join(result) + ' parameter is most often susceptible to Insecure Direct Object Reference Vulnerabilities. \n\nDirect object reference vulnerabilities occur when there are insufficient authorization checks performed against object identifiers used in requests. This could occur when database keys, filenames, or other identifiers are used to directly access resources within an application. \nThese identifiers would likely be predictable (an incrementing counter, the name of a file, etc), making it easy for an attacker to detect this vulnerability class. If further authorization checks are not performed, this could lead to unauthorized access to the underlying data.\nHUNT recommends further manual analysis of the parameter in question.\n\nFor Insecure Direct Object Reference Vulnerabilities HUNT recommends the following resources to aid in manual testing:\n\n- The Web Application Hackers Handbook: Chapter 8\n- Testing for Insecure Direct Object References (OTG-AUTHZ-004): https://www.owasp.org/index.php/Testing_for_Insecure_Direct_Object_References_(OTG-AUTHZ-004) \n- Using Burp to Test for Insecure Direct Object References: https://support.portswigger.net/customer/portal/articles/1965691-using-burp-to-test-for-insecure-direct-object-references\n- IDOR Examples from ngalongc/bug-bounty-reference: https://github.com/ngalongc/bug-bounty-reference#insecure-direct-object-reference-idor',
-                msg.getRequestHeader().getURI().toString(),
-                ','.join(result), '', msg.getRequestHeader().toString()+'\n'+msg.getRequestBody().toString(), '', '', 0, 0, msg);
+        if result:
+            ps.raiseAlert(0, 1, 'Possible IDOR', 'HUNT located the ' + ','.join(result) + ' parameter inside of your application traffic. The ' + ','.join(result) + ' parameter is most often susceptible to Insecure Direct Object Reference Vulnerabilities. \n\nDirect object reference vulnerabilities occur when there are insufficient authorization checks performed against object identifiers used in requests. This could occur when database keys, filenames, or other identifiers are used to directly access resources within an application. \nThese identifiers would likely be predictable (an incrementing counter, the name of a file, etc), making it easy for an attacker to detect this vulnerability class. If further authorization checks are not performed, this could lead to unauthorized access to the underlying data.\nHUNT recommends further manual analysis of the parameter in question.\n\nFor Insecure Direct Object Reference Vulnerabilities HUNT recommends the following resources to aid in manual testing:\n\n- The Web Application Hackers Handbook: Chapter 8\n- Testing for Insecure Direct Object References (OTG-AUTHZ-004): https://www.owasp.org/index.php/Testing_for_Insecure_Direct_Object_References_(OTG-AUTHZ-004) \n- Using Burp to Test for Insecure Direct Object References: https://support.portswigger.net/customer/portal/articles/1965691-using-burp-to-test-for-insecure-direct-object-references\n- IDOR Examples from ngalongc/bug-bounty-reference: https://github.com/ngalongc/bug-bounty-reference#insecure-direct-object-reference-idor',
+            msg.getRequestHeader().getURI().toString(),
+            ','.join(result), '', msg.getRequestHeader().toString()+'\n'+msg.getRequestBody().toString(), '', '', 0, 0, msg);
 
-            # Searching RCEs
-            result = []
-            for x in words_prce:
-                y = re.compile(".*"+x)
-                if len(filter(y.match, params))>0:
-                    result.append(x)
+        # Searching RCEs
+        result = []
+        for x in words_prce:
+            y = re.compile(".*"+x)
+            if len(filter(y.match, params))>0:
+                result.append(x)
 
-            if result:
-                ps.raiseAlert(0, 1, 'Possible RCE', 'HUNT located the ' + ','.join(result) + ' parameter inside of your application traffic. The ' + ','.join(result) + ' parameter is most often susceptible to OS Command Injection. HUNT recommends further manual analysis of the parameter in question.\n\nFor OS Command Injection HUNT recommends the following resources to aid in manual testing:\n\n- (OWASP) Testing for OS Command Injection: https://www.owasp.org/index.php/Testing_for_Command_Injection_(OTG-INPVAL-013)\n- Joberts How To Command Injection: https://www.hackerone.com/blog/how-to-command-injections \n- Commix Command Injection Tool: https://github.com/commixproject/commix\n-The FuzzDB OS CMD Exec section: https://github.com/fuzzdb-project/fuzzdb/tree/master/attack/os-cmd-execution \n- Ferruh Mavitunas CMDi Cheat Sheet: https://ferruh.mavituna.com/unix-command-injection-cheat-sheet-oku/ \nThe Web Application Hackers Handbook: Chapter 10',
-                msg.getRequestHeader().getURI().toString(),
-                ','.join(result), '', msg.getRequestHeader().toString()+'\n'+msg.getRequestBody().toString(), '', '', 0, 0, msg);
+        if result:
+            ps.raiseAlert(0, 1, 'Possible RCE', 'HUNT located the ' + ','.join(result) + ' parameter inside of your application traffic. The ' + ','.join(result) + ' parameter is most often susceptible to OS Command Injection. HUNT recommends further manual analysis of the parameter in question.\n\nFor OS Command Injection HUNT recommends the following resources to aid in manual testing:\n\n- (OWASP) Testing for OS Command Injection: https://www.owasp.org/index.php/Testing_for_Command_Injection_(OTG-INPVAL-013)\n- Joberts How To Command Injection: https://www.hackerone.com/blog/how-to-command-injections \n- Commix Command Injection Tool: https://github.com/commixproject/commix\n-The FuzzDB OS CMD Exec section: https://github.com/fuzzdb-project/fuzzdb/tree/master/attack/os-cmd-execution \n- Ferruh Mavitunas CMDi Cheat Sheet: https://ferruh.mavituna.com/unix-command-injection-cheat-sheet-oku/ \nThe Web Application Hackers Handbook: Chapter 10',
+            msg.getRequestHeader().getURI().toString(),
+            ','.join(result), '', msg.getRequestHeader().toString()+'\n'+msg.getRequestBody().toString(), '', '', 0, 0, msg);
 
-            # Searching SQLi
-            result = []
-            for x in words_psql:
-                y = re.compile(".*"+x)
-                if len(filter(y.match, params))>0:
-                    result.append(x)
+        # Searching SQLi
+        result = []
+        for x in words_psql:
+            y = re.compile(".*"+x)
+            if len(filter(y.match, params))>0:
+                result.append(x)
 
-            if result:
-                ps.raiseAlert(0, 1, 'Possible SQLi', 'HUNT located the parameter inside of your application traffic. The parameter is most often susceptible to SQL Injection. HUNT recommends further manual analysis of the parameter in question.\n\nFor SQL Injection HUNT references The Bug Hunters Methodology SQL Injection references table:\n\n- PentestMonkeys MySQL Injection Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/mysql-sql-injection-cheat-sheet \n\n- Reiners MySQL Injection Filter Evasion: https://websec.wordpress.com/2010/12/04/sqli-filter-evasion-cheat-sheet-mysql/ \n- EvilSQLs Error/Union/Blind MSSQL Cheat Sheet: http://evilsql.com/main/page2.php \n- PentestMonkeys MSSQL SQL Injection Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/mssql-sql-injection-cheat-sheet \n- PentestMonkeys Oracle SQL Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/oracle-sql-injection-cheat-sheet \n- PentestMonkeys PostgreSQL Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/postgres-sql-injection-cheat-sheet \n- Access SQL Injection Cheat Sheet: http://nibblesec.org/files/MSAccessSQLi/MSAccessSQLi.html \n- PentestMonkeys Ingres SQL Injection Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/ingres-sql-injection-cheat-sheet \n- PentestMonkeys DB2 SQL Injection Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/db2-sql-injection-cheat-sheet \n- PentestMonkeys Informix SQL Injection Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/informix-sql-injection-cheat-sheet \n- SQLite3 Injection Cheat Sheet: https://sites.google.com/site/0x7674/home/sqlite3injectioncheatsheet \n- Ruby on Rails (ActiveRecord) SQL Injection Guide: https://sites.google.com/site/0x7674/home/sqlite3injectioncheatsheet',
-                msg.getRequestHeader().getURI().toString(),
-                ','.join(result), '', msg.getRequestHeader().toString()+'\n'+msg.getRequestBody().toString(), '',
-                '', 0, 0, msg);
+        if result:
+            ps.raiseAlert(0, 1, 'Possible SQLi', 'HUNT located the parameter inside of your application traffic. The parameter is most often susceptible to SQL Injection. HUNT recommends further manual analysis of the parameter in question.\n\nFor SQL Injection HUNT references The Bug Hunters Methodology SQL Injection references table:\n\n- PentestMonkeys MySQL Injection Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/mysql-sql-injection-cheat-sheet \n\n- Reiners MySQL Injection Filter Evasion: https://websec.wordpress.com/2010/12/04/sqli-filter-evasion-cheat-sheet-mysql/ \n- EvilSQLs Error/Union/Blind MSSQL Cheat Sheet: http://evilsql.com/main/page2.php \n- PentestMonkeys MSSQL SQL Injection Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/mssql-sql-injection-cheat-sheet \n- PentestMonkeys Oracle SQL Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/oracle-sql-injection-cheat-sheet \n- PentestMonkeys PostgreSQL Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/postgres-sql-injection-cheat-sheet \n- Access SQL Injection Cheat Sheet: http://nibblesec.org/files/MSAccessSQLi/MSAccessSQLi.html \n- PentestMonkeys Ingres SQL Injection Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/ingres-sql-injection-cheat-sheet \n- PentestMonkeys DB2 SQL Injection Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/db2-sql-injection-cheat-sheet \n- PentestMonkeys Informix SQL Injection Cheat Sheet: http://pentestmonkey.net/cheat-sheet/sql-injection/informix-sql-injection-cheat-sheet \n- SQLite3 Injection Cheat Sheet: https://sites.google.com/site/0x7674/home/sqlite3injectioncheatsheet \n- Ruby on Rails (ActiveRecord) SQL Injection Guide: https://sites.google.com/site/0x7674/home/sqlite3injectioncheatsheet',
+            msg.getRequestHeader().getURI().toString(),
+            ','.join(result), '', msg.getRequestHeader().toString()+'\n'+msg.getRequestBody().toString(), '',
+            '', 0, 0, msg);
 
-            # Searching SSRF
-            result = []
-            for x in words_pssrf:
-                y = re.compile(".*"+x)
-                if len(filter(y.match, params))>0:
-                    result.append(x)
+        # Searching SSRF
+        result = []
+        for x in words_pssrf:
+            y = re.compile(".*"+x)
+            if len(filter(y.match, params))>0:
+                result.append(x)
 
-            if result:
-                ps.raiseAlert(0, 1, 'Possible SSRF', 'HUNT located the ' + ','.join(result) + ' parameter inside of your application traffic. The ' + ','.join(result) + ' parameter is most often susceptible to Server Side Request Forgery (and sometimes URL redirects). HUNT recommends further manual analysis of the parameter in question.\n\nFor Server Side Request Forgery HUNT recommends the following resources to aid in manual testing:\n\n- Server-side browsing considered harmful - Nicolas Gregoire: http://www.agarri.fr/docs/AppSecEU15-Server_side_browsing_considered_harmful.pdf \n- How To: Server-Side Request Forgery (SSRF) - Jobert Abma: https://www.hackerone.com/blog-How-To-Server-Side-Request-Forgery-SSRF \n- SSRF Examples from ngalongc/bug-bounty-reference: https://github.com/ngalongc/bug-bounty-reference#server-side-request-forgery-ssrf \n- Safebuff SSRF Tips: http://blog.safebuff.com/2016/07/03/SSRF-Tips/ \n- The SSRF Bible: https://docs.google.com/document/d/1v1TkWZtrhzRLy0bYXBcdLUedXGb9njTNIJXa3u9akHM/edit',
-                msg.getRequestHeader().getURI().toString(),
-                ','.join(result), '', msg.getRequestHeader().toString()+'\n'+msg.getRequestBody().toString(), '', '', 0, 0, msg);
+        if result:
+            ps.raiseAlert(0, 1, 'Possible SSRF', 'HUNT located the ' + ','.join(result) + ' parameter inside of your application traffic. The ' + ','.join(result) + ' parameter is most often susceptible to Server Side Request Forgery (and sometimes URL redirects). HUNT recommends further manual analysis of the parameter in question.\n\nFor Server Side Request Forgery HUNT recommends the following resources to aid in manual testing:\n\n- Server-side browsing considered harmful - Nicolas Gregoire: http://www.agarri.fr/docs/AppSecEU15-Server_side_browsing_considered_harmful.pdf \n- How To: Server-Side Request Forgery (SSRF) - Jobert Abma: https://www.hackerone.com/blog-How-To-Server-Side-Request-Forgery-SSRF \n- SSRF Examples from ngalongc/bug-bounty-reference: https://github.com/ngalongc/bug-bounty-reference#server-side-request-forgery-ssrf \n- Safebuff SSRF Tips: http://blog.safebuff.com/2016/07/03/SSRF-Tips/ \n- The SSRF Bible: https://docs.google.com/document/d/1v1TkWZtrhzRLy0bYXBcdLUedXGb9njTNIJXa3u9akHM/edit',
+            msg.getRequestHeader().getURI().toString(),
+            ','.join(result), '', msg.getRequestHeader().toString()+'\n'+msg.getRequestBody().toString(), '', '', 0, 0, msg);
 
-            # Searching SSTI
-            result = []
-            for x in words_pssti:
-                y = re.compile(".*"+x)
-                if len(filter(y.match, params))>0:
-                    result.append(x)
+        # Searching SSTI
+        result = []
+        for x in words_pssti:
+            y = re.compile(".*"+x)
+            if len(filter(y.match, params))>0:
+                result.append(x)
 
-            if result:
-                ps.raiseAlert(0, 1, 'Possible SSTI', 'HUNT located the ' + ','.join(result) + ' parameter inside of your application traffic. The ' + ','.join(result) + ' parameter is most often susceptible to Server Side Template Injection. HUNT recommends further manual analysis of the parameter in question.',
-                msg.getRequestHeader().getURI().toString(),
-                ','.join(result), '', msg.getRequestHeader().toString()+'\n'+msg.getRequestBody().toString(), '', '', 0, 0, msg);
+        if result:
+            ps.raiseAlert(0, 1, 'Possible SSTI', 'HUNT located the ' + ','.join(result) + ' parameter inside of your application traffic. The ' + ','.join(result) + ' parameter is most often susceptible to Server Side Template Injection. HUNT recommends further manual analysis of the parameter in question.',
+            msg.getRequestHeader().getURI().toString(),
+            ','.join(result), '', msg.getRequestHeader().toString()+'\n'+msg.getRequestBody().toString(), '', '', 0, 0, msg);


### PR DESCRIPTION
## Commit list (most recent first)

commit 952be4c0896d8f482a5693498e07e2e340fdc8b4

    HUNT.py: add '(HUNT script)' as alert title suffix
---
commit 4b992ef7d58fb6a99c2d8f273bed2ca8c1ae9fee

    HUNT.py: factorize alert, improve code readability
    
    - factorize alert creation into `hunt_alert()` function
    - make alert descriptions more readable
---
commit 09b9e4620399ac940911c1edf3bd6aa11143f0e3

    HUNT.py: add function for redundant match code
    
    * The `result` matches where always the same, so separated it
      into a separate function.
    * As `re.match('.*X', string)` is equal to `X in string`, stop
      using regex in `find_words_in_params()` to improve readability.
---
commit 7741e05f93ab513b02b67a8275f5ff368f846f93

    HUNT.py: refactor code
    
    * remove unneeder cast to str()
    * remove unneeded `globalvar` initialization
    * rename `regex` var (which is not a regex)
    * limit unneeded nesting
---
commit ab5e6d6ab6f228dda9564bed915ba0e9cf31b229

    HUNT.py: perf: leave script if not params
---
commit 247cc0ae2e252a1a4b3c8f3586f85602e8ebf2f8

    HUNT.py: refactor: limit unneeded nesting
---
commit a138a0d40e255626e09d52c7e1e943cda3b45833

    HUNT.py: improve base_uri regex performance
    
    previous regex had useless capturing groups
    and didn't ensure that match is found at start of string ('^')
---
commit 87551dcaa351e275bd9940c869b2860656b44cce

    HUNT.py: fix appliesToHistoryType() condition
    
    previous condition was `histType <= 2`, which also includes
    TYPE_TEMPORARY.
    
    NOTE: new condition written in order to be easy to understand.