### PR TITLE
Use line feeds always

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-* text=auto
+* text=lf
 
 *.conf text
 *.gradle text
@@ -13,7 +13,7 @@
 *.zst text
 
 *.bat text eol=crlf
-*.sh text eol=lf
-gradlew text eol=lf
+*.sh text
+gradlew text
 
 *.jar binary


### PR DESCRIPTION
Change `.gitattributes` to use line feeds (instead of auto) to make
reproducible builds easier everywhere.

---
Related to zaproxy/zaproxy#4948.