### PR TITLE
Remove ZapVersions configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,10 +38,6 @@ zapAddOn {
         wikiFilesPrefix.set("HelpAddons${zapAddOn.addOnId.get().capitalize()}")
         wikiDir.set(file("$rootDir/../zap-extensions-wiki/"))
     }
-
-    zapVersions {
-        downloadUrl.set("https://github.com/zaproxy/community-scripts/releases/download/v$version")
-    }
 }
 
 val jupiterVersion = "5.2.0"


### PR DESCRIPTION
The generation of the ZapVersions.xml data will be done in the zap-admin
repository when needed.