### PR TITLE
Correct gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-* text=lf
+* text=auto eol=lf
 
 *.conf text
 *.gradle text


### PR DESCRIPTION
Correct default text declaration.
Remove redundant text attribute in bat files.