### PR TITLE
Update Gradle and add-on plugin

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,0 +1,23 @@
+workflow "Release Add-On" {
+  on = "push"
+  resolves = ["Build and Release Add-On"]
+}
+
+action "Add-On Tag Filter" {
+  uses = "actions/bin/filter@3c0b4f0e63ea54ea5df2914b4fabf383368cd0da"
+  args = "tag v*"
+}
+
+action "Actor Filter" {
+  uses = "actions/bin/filter@3c0b4f0e63ea54ea5df2914b4fabf383368cd0da"
+  needs = ["Add-On Tag Filter"]
+  args = ["actor", "kingthorin", "psiinon", "thc202"]
+}
+
+action "Build and Release Add-On" {
+  uses = "docker://openjdk:8"
+  needs = ["Actor Filter"]
+  runs = "./gradlew"
+  args = "createReleaseFromGitHubRef"
+  secrets = ["GITHUB_TOKEN"]
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,12 @@
+import org.zaproxy.gradle.addon.AddOnPlugin
 import org.zaproxy.gradle.addon.AddOnStatus
-import org.zaproxy.gradle.addon.manifest.tasks.ConvertChangelogToChanges
+import org.zaproxy.gradle.addon.misc.ConvertMarkdownToHtml
+import org.zaproxy.gradle.addon.misc.CreateGitHubRelease
+import org.zaproxy.gradle.addon.misc.ExtractLatestChangesFromChangelog
 
 plugins {
     `java-library`
-    id("org.zaproxy.add-on") version "0.1.0"
+    id("org.zaproxy.add-on") version "0.2.0"
     id("com.diffplug.gradle.spotless") version "3.15.0"
 }
 
@@ -16,21 +19,19 @@ description = "Useful ZAP scripts written by the ZAP community."
 
 val scriptsDir = layout.buildDirectory.dir("scripts")
 
-val generateManifestChanges by tasks.registering(ConvertChangelogToChanges::class) {
-    changelog.set(file("CHANGELOG.md"))
-    manifestChanges.set(file("$buildDir/zapAddOn/manifest-changes.html"))
-}
-
 zapAddOn {
     addOnId.set("communityScripts")
     addOnName.set("Community Scripts")
     zapVersion.set("2.7.0")
     addOnStatus.set(AddOnStatus.ALPHA)
 
+    releaseLink.set("https://github.com/zaproxy/community-scripts/compare/v@PREVIOUS_VERSION@...v@CURRENT_VERSION@")
+    unreleasedLink.set("https://github.com/zaproxy/community-scripts/compare/v@CURRENT_VERSION@...HEAD")
+
     manifest {
         author.set("ZAP Community")
         url.set("https://github.com/zaproxy/community-scripts")
-        changesFile.set(generateManifestChanges.flatMap { it.manifestChanges })
+        changesFile.set(tasks.named<ConvertMarkdownToHtml>("generateManifestChanges").flatMap { it.html })
         files.from(scriptsDir)
     }
 
@@ -105,5 +106,36 @@ spotless {
         licenseHeaderFile("$rootDir/gradle/spotless/license.java")
 
         googleJavaFormat().aosp()
+    }
+}
+
+System.getenv("GITHUB_REF")?.let { ref ->
+    if ("refs/tags/" !in ref) {
+        return@let
+    }
+
+    tasks.register<CreateGitHubRelease>("createReleaseFromGitHubRef") {
+        val targetTag = ref.removePrefix("refs/tags/")
+        val targetAddOnVersion = targetTag.removePrefix("v")
+
+        authToken.set(System.getenv("GITHUB_TOKEN"))
+        repo.set(System.getenv("GITHUB_REPOSITORY"))
+        tag.set(targetTag)
+
+        title.set(provider { "Version ${zapAddOn.addOnVersion.get()}" })
+        bodyFile.set(tasks.named<ExtractLatestChangesFromChangelog>("extractLatestChanges").flatMap { it.latestChanges })
+
+        assets {
+            register("add-on") {
+                file.set(tasks.named<Jar>(AddOnPlugin.JAR_ZAP_ADD_ON_TASK_NAME).flatMap { it.archiveFile })
+            }
+        }
+
+        doFirst {
+            val addOnVersion = zapAddOn.addOnVersion.get()
+            require(addOnVersion == targetAddOnVersion) {
+                "Version of the tag $targetAddOnVersion does not match the version of the add-on $addOnVersion"
+            }
+        }
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Update Gradle to 5.4.1 and add-on plugin to 0.2.0.
Update build accordingly.
Add GitHub Actions workflow and Gradle task to release on tag.

---
WIP until zaproxy is updated (zaproxy/zaproxy#5369).