### PR TITLE
Add Unified Scan Rule List JS Standalone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - active/cve-2019-5418.js > An active scanner for Ruby on Rails Accept header content disclosure issue.
 - authentication/DjangoAuthentication.js > Django authentication script.
+- standalone/scan_rule_list.js that list details from both active and passive scan rules.
 
 ### Changed
 - Misc maintenance changes.
+- Maintenance changes to target ZAP 2.8.
 
 ## 8 - 2018-06-19
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ val scriptsDir = layout.buildDirectory.dir("scripts")
 zapAddOn {
     addOnId.set("communityScripts")
     addOnName.set("Community Scripts")
-    zapVersion.set("2.7.0")
+    zapVersion.set("2.8.0")
     addOnStatus.set(AddOnStatus.ALPHA)
 
     releaseLink.set("https://github.com/zaproxy/community-scripts/compare/v@PREVIOUS_VERSION@...v@CURRENT_VERSION@")
@@ -50,8 +50,6 @@ dependencies {
 
     testImplementation("org.assertj:assertj-core:3.11.0")
     testImplementation("org.apache.commons:commons-lang3:3.8")
-
-    testRuntimeOnly("org.zaproxy:zap:2.7.0")
 
     // The following versions should match the ones of the add-ons.
     testImplementation("org.codehaus.groovy:groovy-all:2.4.14")

--- a/standalone/scan_rule_list.js
+++ b/standalone/scan_rule_list.js
@@ -1,0 +1,30 @@
+// This script gives details about all of the scan rules installed
+
+extAscan = org.parosproxy.paros.control.Control.getSingleton().
+    getExtensionLoader().getExtension(
+        org.zaproxy.zap.extension.ascan.ExtensionActiveScan.NAME);
+
+plugins = extAscan.getPolicyManager().getDefaultScanPolicy().getPluginFactory().getAllPlugin().toArray();
+
+print('Plugin ID\tName\tType\tStatus');
+for (var i=0; i < plugins.length; i++) {
+  try {
+    print(plugins[i].getId()+ '\t' + plugins[i].getName() + '\tActive' + '\t' + plugins[i].getStatus());
+  } catch (e) {
+    print(e);
+  }
+}
+
+extPscan = org.parosproxy.paros.control.Control.getSingleton().
+    getExtensionLoader().getExtension(
+        org.zaproxy.zap.extension.pscan.ExtensionPassiveScan.NAME);
+
+plugins = extPscan.getPluginPassiveScanners().toArray();
+
+for (var i=0; i < plugins.length; i++) {
+  try {
+    print(plugins[i].getPluginId()+ '\t' + plugins[i].getName() + '\tPassive' + '\t' + plugins[i].getStatus());
+  } catch (e) {
+    print(e);
+  }
+}


### PR DESCRIPTION
Leverages https://github.com/zaproxy/zaproxy/pull/4474

- Added standalone/scan_rule_list.js that list details from both active and passive scan rules.
- Maintenance changes to target ZAP 2.8.

Output sample (tested to paste well in Excel or Google Sheets):
```
Plugin ID	Name	Type	Status
6	Path Traversal	Active	release
7	Remote File Inclusion	Active	release
10045	Source Code Disclosure - /WEB-INF folder	Active	release
40009	Server Side Include	Active	release
40012	Cross Site Scripting (Reflected)	Active	release
40014	Cross Site Scripting (Persistent)	Active	release
40018	SQL Injection	Active	release
90019	Server Side Code Injection	Active	release
90020	Remote OS Command Injection	Active	release
0	Directory Browsing	Active	release
20019	External Redirect	Active	release
30001	Buffer Overflow	Active	release
30002	Format String Error	Active	release
40003	CRLF Injection	Active	release
40008	Parameter Tampering	Active	release
40016	Cross Site Scripting (Persistent) - Prime	Active	release
40017	Cross Site Scripting (Persistent) - Spider	Active	release
50000	Script Active Scan Rules	Active	release
10048	Remote Code Execution - Shell Shock	Active	beta
20012	Anti CSRF Tokens Scanner	Active	beta
20015	Heartbleed OpenSSL Vulnerability	Active	beta
20016	Cross-Domain Misconfiguration	Active	beta
20017	Source Code Disclosure - CVE-2012-1823	Active	beta
20018	Remote Code Execution - CVE-2012-1823	Active	beta
40013	Session Fixation	Active	beta
40019	SQL Injection - MySQL	Active	beta
40020	SQL Injection - Hypersonic SQL	Active	beta
40021	SQL Injection - Oracle	Active	beta
40022	SQL Injection - PostgreSQL	Active	beta
90021	XPath Injection	Active	beta
90023	XML External Entity Attack	Active	beta
90024	Generic Padding Oracle	Active	beta
90025	Expression Language Injection	Active	beta
42	Source Code Disclosure - SVN	Active	beta
10095	Backup File Disclosure	Active	beta
30003	Integer Overflow Error	Active	beta
90028	Insecure HTTP Method	Active	beta
20014	HTTP Parameter Pollution scanner	Active	beta
40023	Possible Username Enumeration	Active	beta
50001	Script Passive Scan Rules	Passive	release
50003	Stats Passive Scan Rule	Passive	release
10054	Cookie Without SameSite Attribute	Passive	beta
10098	Cross-Domain Misconfiguration	Passive	beta
10024	Information Disclosure - Sensitive Information in URL	Passive	beta
10025	Information Disclosure - Sensitive Information in HTTP Referrer Header	Passive	beta
10027	Information Disclosure - Suspicious Comments	Passive	beta
10026	HTTP Parameter Override	Passive	beta
10096	Timestamp Disclosure	Passive	beta
10057	Username Hash Found	Passive	beta
10061	X-AspNet-Version Response Header Scanner	Passive	beta
10056	X-Debug-Token Information Leak	Passive	beta
10037	Server Leaks Information via "X-Powered-By" HTTP Response Header Field(s)	Passive	beta
90022	Application Error Disclosure	Passive	release
10015	Incomplete or No Cache-control and Pragma HTTP Header Set	Passive	release
10055	CSP Scanner	Passive	release
10019	Content-Type Header Missing	Passive	release
10010	Cookie No HttpOnly Flag	Passive	release
10011	Cookie Without Secure Flag	Passive	release
10017	Cross-Domain JavaScript Source File Inclusion	Passive	release
10016	Web Browser XSS Protection Not Enabled	Passive	release
10040	Secure Pages Include Mixed Content	Passive	release
2	Private IP Disclosure	Passive	release
3	Session ID in URL Rewrite	Passive	release
10021	X-Content-Type-Options Header Missing	Passive	release
10020	X-Frame-Options Header Scanner	Passive	release
10094	Base64 Disclosure	Passive	alpha
10044	Big Redirect Detected (Potential Sensitive Information Leak)	Passive	alpha
10049	Content Cacheability	Passive	alpha
10038	Content Security Policy (CSP) Header Not Set	Passive	alpha
10033	Directory Browsing	Passive	alpha
60001	An example passive scan rule which loads data from a file	Passive	alpha
60000	Example Passive Scanner: Denial of Service	Passive	alpha
10063	Feature Policy Header Not Set	Passive	alpha
10097	Hash Disclosure	Passive	alpha
10034	Heartbleed OpenSSL Vulnerability (Indicative)	Passive	alpha
10009	In Page Banner Information Leak	Passive	alpha
10046	Insecure Component	Passive	alpha
10041	HTTP to HTTPS Insecure Transition in Form Post	Passive	alpha
10042	HTTPS to HTTP Insecure Transition in Form Post	Passive	alpha
10108	Reverse Tabnabbing	Passive	alpha
10062	PII Scanner	Passive	alpha
10050	Retrieved from Cache	Passive	alpha
10036	HTTP Server Response Header Scanner	Passive	alpha
10099	Source Code Disclosure	Passive	alpha
10035	Strict-Transport-Security Header Scanner	Passive	alpha
10030	User Controllable Charset	Passive	alpha
10029	Cookie Poisoning	Passive	alpha
10031	User Controllable HTML Element Attribute (Potential XSS)	Passive	alpha
10043	User Controllable JavaScript Event (XSS)	Passive	alpha
10028	Open Redirect	Passive	alpha
10039	X-Backend-Server Header Information Leak	Passive	alpha
10052	X-ChromeLogger-Data (XCOLD) Header Information Leak	Passive	alpha
```

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>