### PR TITLE
Fix links to source files and update JavaDoc links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Misc maintenance changes.
 - Maintenance changes to target ZAP 2.8.
 
+### Fixed
+- Fix links to source files in zaproxy repo.
+
 ## 8 - 2018-06-19
 
 - Update from community-scripts repo.

--- a/httpfuzzerprocessor/README.md
+++ b/httpfuzzerprocessor/README.md
@@ -69,7 +69,7 @@ function processResult(utils, fuzzResult){
 ## Parameters
 | Name | JavaDoc |
 | --- | --- |
-| message | [HttpMessage](https://static.javadoc.io/org.zaproxy/zap/2.7.0/org/parosproxy/paros/network/HttpMessage.html) |
+| message | [HttpMessage](https://static.javadoc.io/org.zaproxy/zap/2.8.0/org/parosproxy/paros/network/HttpMessage.html) |
 
 ## Code Links
 | Name | Source |

--- a/httpsender/README.md
+++ b/httpsender/README.md
@@ -25,7 +25,7 @@ They are invoked for proxied requests and requests that originate from ZAP, for 
 // 		9	ACCESS_CONTROL_SCANNER_INITIATOR
 // 		10	AJAX_SPIDER_INITIATOR
 // For the latest list of values see the HttpSender class:
-// https://github.com/zaproxy/zaproxy/blob/master/src/org/parosproxy/paros/network/HttpSender.java
+// https://github.com/zaproxy/zaproxy/blob/master/zap/src/main/java/org/parosproxy/paros/network/HttpSender.java
 // 'helper' just has one method at the moment: helper.getHttpSender() which returns the HttpSender 
 // instance used to send the request.
 //
@@ -47,10 +47,10 @@ function responseReceived(msg, initiator, helper) {
 ## Variables
 | Name | Javadocs |
 | --- | --- |
-| msg | [HttpMessage](https://static.javadoc.io/org.zaproxy/zap/2.7.0/org/parosproxy/paros/network/HttpMessage.html) |
+| msg | [HttpMessage](https://static.javadoc.io/org.zaproxy/zap/2.8.0/org/parosproxy/paros/network/HttpMessage.html) |
 | initiator | int |
-| helper | [HttpSenderScriptHelper](https://static.javadoc.io/org.zaproxy/zap/2.7.0/org/zaproxy/zap/extension/script/HttpSenderScriptHelper.html) |
+| helper | [HttpSenderScriptHelper](https://static.javadoc.io/org.zaproxy/zap/2.8.0/org/zaproxy/zap/extension/script/HttpSenderScriptHelper.html) |
 
 ## Code Links
-* [HttpSenderScript.java](https://github.com/zaproxy/zaproxy/blob/master/src/org/zaproxy/zap/extension/script/HttpSenderScript.java)
-* [HttpSender.java](https://github.com/zaproxy/zaproxy/blob/master/src/org/parosproxy/paros/network/HttpSender.java)
+* [HttpSenderScript.java](https://github.com/zaproxy/zaproxy/blob/master/zap/src/main/java/org/zaproxy/zap/extension/script/HttpSenderScript.java)
+* [HttpSender.java](https://github.com/zaproxy/zaproxy/blob/master/zap/src/main/java/org/parosproxy/paros/network/HttpSender.java)

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -43,8 +43,8 @@ function proxyResponse(msg) {
 ## Variables
 | Name | Javadocs |
 | --- | --- |
-| msg | [HttpMessage](https://static.javadoc.io/org.zaproxy/zap/2.7.0/org/parosproxy/paros/network/HttpMessage.html) |
+| msg | [HttpMessage](https://static.javadoc.io/org.zaproxy/zap/2.8.0/org/parosproxy/paros/network/HttpMessage.html) |
 
 ## Code Links
-* [ProxyScript.java](https://github.com/zaproxy/zaproxy/blob/master/src/org/zaproxy/zap/extension/script/ProxyScript.java)
+* [ProxyScript.java](https://github.com/zaproxy/zaproxy/blob/master/zap/src/main/java/org/zaproxy/zap/extension/script/ProxyScript.java)
 

--- a/standalone/Loop through alerts.js
+++ b/standalone/Loop through alerts.js
@@ -14,6 +14,6 @@ if (extAlert != null) {
 		print ('\tName:\t' + alert.name)
 		print ('\tRisk:\t' + Alert.MSG_RISK[alert.risk])
 		print ('\tConfidence:\t' + Alert.MSG_CONFIDENCE[alert.confidence])
-		// For more alert properties see https://static.javadoc.io/org.zaproxy/zap/2.7.0/org/parosproxy/paros/core/scanner/Alert.html
+		// For more alert properties see https://static.javadoc.io/org.zaproxy/zap/2.8.0/org/parosproxy/paros/core/scanner/Alert.html
 	}
 }

--- a/standalone/alertAndPluginDetails.js
+++ b/standalone/alertAndPluginDetails.js
@@ -49,5 +49,5 @@ function printAlert(alert) {
         }
     }
     print(alert.getName() + '\t' + alert.getSource() + ':' + scanner + '\t' + alert.getWascId()  + '\t' + alert.getCweId());
-    // For more alert properties see https://static.javadoc.io/org.zaproxy/zap/2.7.0/org/parosproxy/paros/core/scanner/Alert.html
+    // For more alert properties see https://static.javadoc.io/org.zaproxy/zap/2.8.0/org/parosproxy/paros/core/scanner/Alert.html
 }


### PR DESCRIPTION
Use the new dir path to source files in zaproxy.
Update JavaDoc links to 2.8.0.

Related to zaproxy/zaproxy#5369.