### PR TITLE
Update add-on plugin and help links, tweak HelpSet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 ### Added
+- Add repo URL, shown in the marketplace and Manage Add-ons dialogue.
 - active/cve-2019-5418.js > An active scanner for Ruby on Rails Accept header content disclosure issue.
 - active/JWT None Exploit.js > Checks if the application's JWT implementation allows the usage of the 'none' algorithm.
 - authentication/DjangoAuthentication.js > Django authentication script.
@@ -28,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Maintenance changes to target ZAP 2.8.
+- Change info URL to link to the online help page.
 
 ### Removed
 - The following scripts were merged into a new script `HUNT.py`:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ If you might want to contribute to the repo then you can also clone it to a loca
 Please upload your scripts via pull requests!
 
 For more information on ZAP scripts see:
-* https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsScriptsScripts
+* https://www.zaproxy.org/docs/desktop/addons/script-console/
 * https://github.com/zaproxy/zaproxy/wiki/InternalScripting
  
 To discuss any aspect of ZAP scripting please join the zaproxy-scripts group: http://groups.google.com/group/zaproxy-scripts

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ import org.zaproxy.gradle.addon.misc.ExtractLatestChangesFromChangelog
 
 plugins {
     `java-library`
-    id("org.zaproxy.add-on") version "0.2.0"
+    id("org.zaproxy.add-on") version "0.3.0"
     id("com.diffplug.gradle.spotless") version "3.15.0"
 }
 
@@ -30,14 +30,10 @@ zapAddOn {
 
     manifest {
         author.set("ZAP Community")
-        url.set("https://github.com/zaproxy/community-scripts")
+        url.set("https://www.zaproxy.org/docs/desktop/addons/community-scripts/")
+        repo.set("https://github.com/zaproxy/community-scripts/")
         changesFile.set(tasks.named<ConvertMarkdownToHtml>("generateManifestChanges").flatMap { it.html })
         files.from(scriptsDir)
-    }
-
-    wikiGen {
-        wikiFilesPrefix.set("HelpAddons${zapAddOn.addOnId.get().capitalize()}")
-        wikiDir.set(file("$rootDir/../zap-extensions-wiki/"))
     }
 }
 

--- a/src/main/javahelp/org/zaproxy/zap/extension/communityScripts/resources/help/contents/communityScripts.html
+++ b/src/main/javahelp/org/zaproxy/zap/extension/communityScripts/resources/help/contents/communityScripts.html
@@ -15,7 +15,7 @@ Please upload your scripts via pull requests!
 <br><br>
 For more information on ZAP scripts see:
 <ul>
-<li><a href="https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsScriptsScripts">https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsScriptsScripts</a></li>
+<li><a href="https://www.zaproxy.org/docs/desktop/addons/script-console/">Script Console add-on</a></li>
 <li><a href="https://github.com/zaproxy/zaproxy/wiki/InternalScripting">https://github.com/zaproxy/zaproxy/wiki/InternalScripting</a></li>
 </ul>
  

--- a/src/main/javahelp/org/zaproxy/zap/extension/communityScripts/resources/help/helpset.hs
+++ b/src/main/javahelp/org/zaproxy/zap/extension/communityScripts/resources/help/helpset.hs
@@ -3,10 +3,10 @@
   PUBLIC "-//Sun Microsystems Inc.//DTD JavaHelp HelpSet Version 2.0//EN"
          "http://java.sun.com/products/javahelp/helpset_2_0.dtd">
 <helpset version="2.0" xml:lang="en-GB">
-  <title>Community Scripts | ZAP Extension</title>
+  <title>Community Scripts Add-on</title>
 
   <maps>
-     <homeID>top</homeID>
+     <homeID>communityScripts</homeID>
      <mapref location="map.jhm"/>
   </maps>
 


### PR DESCRIPTION
Update add-on plugin to 0.3.0:
 - Specify the repo URL in the add-on manifest.
 - Change info URL to the help page.
 - Remove wiki gen configuration, no longer needed.

Update help links to the new location.
Change HelpSet to link to the main help page and change the title to use
"add-on" instead of "extension".