### PR TITLE
Do not set the background colour of help page

### DIFF
--- a/src/main/javahelp/org/zaproxy/zap/extension/communityScripts/resources/help/contents/communityScripts.html
+++ b/src/main/javahelp/org/zaproxy/zap/extension/communityScripts/resources/help/contents/communityScripts.html
@@ -6,7 +6,7 @@
 Community Scripts
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Community Scripts</H1>
 A collection of ZAP scripts provided by the community held in 
 <a href="https://github.com/zaproxy/community-scripts">https://github.com/zaproxy/community-scripts</a>


### PR DESCRIPTION
Let the UI set the colour of the background, the help page doesn't
require the background to be white.

Part of zaproxy/zaproxy#5542.