### PR TITLE
Fix typo in HTTP Message Logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Removed
 - standalone/loadListInGlobalVariable.js > superseded by core functionality, `ScriptVars.setGlobalCustomVar(...)` and `getGlobalCustomVar(...)`.
 
+### Fixed
+- extender/HTTP Message Logger.js > fix typo in Integer constant.
+
 ## [9] - 2020-01-30
 
 ### Added

--- a/extender/HTTP Message Logger.js
+++ b/extender/HTTP Message Logger.js
@@ -26,7 +26,7 @@ var listener = new HttpSenderListener {
 
     getListenerOrder: function() {
         // Last listener to be notified to include all changes done by other scripts.
-        return Integer.MAX_INT;
+        return Integer.MAX_VALUE;
     },
 
     onHttpRequestSend: function(msg, initiator, sender) {


### PR DESCRIPTION
Correct the name of the constant `Integer.MAX_VALUE`, which caused an
error in other ECMAScript engine than Nashorn.