### PR TITLE
Remove superseded script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - selenium and session scripts.
 - httpfuzzerprocessor/random_x_forwarded_for_ip.js > Set 'X-Forwarded-For' to a random IP value.
 
+### Removed
+- standalone/loadListInGlobalVariable.js > superseded by core functionality, `ScriptVars.setGlobalCustomVar(...)` and `getGlobalCustomVar(...)`.
+
 ## [9] - 2020-01-30
 
 ### Added

--- a/standalone/loadListInGlobalVariable.js
+++ b/standalone/loadListInGlobalVariable.js
@@ -1,9 +1,0 @@
-//@zaproxy-standalone
-
-org.zaproxy.zap.extension.script.ScriptVars.setGlobalVar('LIST', JSON.stringify(['Zaproxy', 'Zap', 'Simon', 'Mozilla']))
-
-var list = JSON.parse(org.zaproxy.zap.extension.script.ScriptVars.getGlobalVar('LIST'))
-
-list.forEach(function(item) {
-	print(item)
-})


### PR DESCRIPTION
ZAP (>=2.9.0) supports adding global/script variables of arbitrary type.