### PR TITLE
Cope with Nashorn not being available

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ zapAddOn {
     }
 }
 
-val jupiterVersion = "5.2.0"
+val jupiterVersion = "5.7.0-M1"
 
 dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api:$jupiterVersion")

--- a/src/test/java/org/zaproxy/VerifyScripts.java
+++ b/src/test/java/org/zaproxy/VerifyScripts.java
@@ -35,6 +35,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -50,6 +51,7 @@ import org.codehaus.groovy.jsr223.GroovyScriptEngineFactory;
 import org.jruby.embed.jsr223.JRubyEngineFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -100,6 +102,12 @@ class VerifyScripts {
     }
 
     private static Stream<Arguments> scriptsJavaScript() {
+        if (!EnumSet.range(JRE.JAVA_8, JRE.JAVA_14).contains(JRE.currentVersion())) {
+            // Nashorn is not bundled in Java 15+
+            getFilesWithExtension(".js");
+            return Stream.empty();
+        }
+
         Compilable engine = (Compilable) new ScriptEngineManager().getEngineByName("ECMAScript");
         assertThat(engine).as("ECMAScript script engine exists.").isNotNull();
         return testData(".js", engine);


### PR DESCRIPTION
Do not try to test JavaScript files with Nashorn when running with newer
Java versions (>= 15), no longer available.
Update JUnit libraries to use newer API for Java version checks.