### PR TITLE
Update for 2.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - httpfuzzerprocessor/random_x_forwarded_for_ip.js > Set 'X-Forwarded-For' to a random IP value.
 - httpfuzzerprocessor/randomUserAgent.js > Set 'User-Agent' to a random user-agent.
 
+### Changed
+- Update minimum ZAP version to 2.10.0.
+- standalone/enableDebugLogging.js > use new Log4j 2 APIs.
+- standalone/window_creation_template.js > no longer extend `AbstractFrame`.
+
 ### Removed
 - standalone/loadListInGlobalVariable.js > superseded by core functionality, `ScriptVars.setGlobalCustomVar(...)` and `getGlobalCustomVar(...)`.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ val scriptsDir = layout.buildDirectory.dir("scripts")
 zapAddOn {
     addOnId.set("communityScripts")
     addOnName.set("Community Scripts")
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
     addOnStatus.set(AddOnStatus.ALPHA)
 
     releaseLink.set("https://github.com/zaproxy/community-scripts/compare/v@PREVIOUS_VERSION@...v@CURRENT_VERSION@")

--- a/standalone/enableDebugLogging.js
+++ b/standalone/enableDebugLogging.js
@@ -1,4 +1,12 @@
+var Level = Java.type("org.apache.logging.log4j.Level")
+var LoggerContext = Java.type("org.apache.logging.log4j.core.LoggerContext")
+
+var context = LoggerContext.getContext()
+var config = context.getConfiguration()
+
 // The following will enable DEBUG logging for the API
-// org.apache.log4j.Logger.getLogger("org.zaproxy.zap.extension.api.API").setLevel(org.apache.log4j.Level.DEBUG);
+// config.getLoggerConfig("org.zaproxy.zap.extension.api.API").setLevel(Level.DEBUG)
 // The following will enable DEBUG logging for the SessionFixation scanner
-org.apache.log4j.Logger.getLogger("org.zaproxy.zap.extension.ascanrulesBeta.SessionFixation").setLevel(org.apache.log4j.Level.DEBUG)
+config.getLoggerConfig("org.zaproxy.zap.extension.ascanrulesBeta.SessionFixation").setLevel(Level.DEBUG)
+
+context.updateLoggers()

--- a/standalone/window_creation_template.js
+++ b/standalone/window_creation_template.js
@@ -5,7 +5,7 @@ var jlabel = Java.type("javax.swing.JLabel");
 var jmenubar = Java.type("javax.swing.JMenuBar");
 var jmenu = Java.type("javax.swing.JMenu");
 var jmenuitem = Java.type("javax.swing.JMenuItem");
-var window = new absframe(){};
+var window = new absframe();
 
 init();
 


### PR DESCRIPTION
Do not extend `AbstractFrame`, it can now be instantiated directly.
Use Log4j 2 API to configure logging.
Change minimum ZAP version to 2.10.0.