### PR TITLE
Update more links to OWASP site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Ignore check for update messages;
   - Include more expected content types.
 - httpsender/aws-signing-for-owasp-zap.py > read AWS environment variables for default values.
-- active/TestInsecureHTTPVerbs.py > correct link to OWASP site.
+- active/TestInsecureHTTPVerbs.py and passive/HUNT.py > correct links to OWASP site.
 
 ### Removed
 - standalone/loadListInGlobalVariable.js > superseded by core functionality, `ScriptVars.setGlobalCustomVar(...)` and `getGlobalCustomVar(...)`.

--- a/passive/HUNT.py
+++ b/passive/HUNT.py
@@ -130,8 +130,8 @@ following resources to aid in manual testing:
 
 - The Web Application Hackers Handbook: \
 Chapter 8
-- Testing for Insecure Direct Object References (OTG-AUTHZ-004): \
-https://www.owasp.org/index.php/Testing_for_Insecure_Direct_Object_References_(OTG-AUTHZ-004)
+- Testing for Insecure Direct Object References (WSTG-ATHZ-04): \
+https://owasp.org/www-project-web-security-testing-guide/v42/4-Web_Application_Security_Testing/05-Authorization_Testing/04-Testing_for_Insecure_Direct_Object_References.html
 - Using Burp to Test for Insecure Direct Object References: \
 https://support.portswigger.net/customer/portal/articles/1965691-using-burp-to-test-for-insecure-direct-object-references
 - IDOR Examples from ngalongc/bug-bounty-reference: \
@@ -150,8 +150,8 @@ HUNT recommends further manual analysis of the parameter in question.
 For OS Command Injection HUNT recommends the following resources to aid \
 in manual testing:
 
-- (OWASP) Testing for OS Command Injection: \
-https://www.owasp.org/index.php/Testing_for_Command_Injection_(OTG-INPVAL-013)
+- (OWASP) Testing for OS Command Injection (WSTG-INPV-12): \
+https://owasp.org/www-project-web-security-testing-guide/v42/4-Web_Application_Security_Testing/07-Input_Validation_Testing/12-Testing_for_Command_Injection.html
 - Joberts How To Command Injection: \
 https://www.hackerone.com/blog/how-to-command-injections
 - Commix Command Injection Tool: \


### PR DESCRIPTION
Link to new site instead of the old wiki, missed in previous pull
request.

---
Pointed out by @ricekot in IRC, thank you!