### PR TITLE
Enable Spotless checks for build scripts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -106,6 +106,10 @@ spotless {
 
         googleJavaFormat("1.7").aosp()
     }
+
+    kotlinGradle {
+        ktlint()
+    }
 }
 
 System.getenv("GITHUB_REF")?.let { ref ->


### PR DESCRIPTION
Check format of Kotlin Gradle scripts.