### PR TITLE
Tidy up resource messages file

### DIFF
--- a/src/main/resources/org/zaproxy/zap/extension/communityScripts/resources/Messages.properties
+++ b/src/main/resources/org/zaproxy/zap/extension/communityScripts/resources/Messages.properties
@@ -1,4 +1,2 @@
-# This file defines the default (English) variants of all of the internationalised messages
-
-communityScripts.name		= Community Scripts
-communityScripts.desc		= Community Scripts from https://github.com/zaproxy/community-scripts
+communityScripts.name = Community Scripts
+communityScripts.desc = Community Scripts from https://github.com/zaproxy/community-scripts


### PR DESCRIPTION
Remove comment that says it's the default file as that gets copied to
the localized files.
Remove tabs after the keys.