### PR TITLE
handle an OAUTH2 offline token refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Added
 - authentication/OfflineTokenRefresh.js - refresh oauth2 offline tokens
 - httpsender/AddBearerTokenHeader.js - refresh oauth2 offline tokens
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - active/Cross Site WebSocket Hijacking.js > an active scan for Cross-Site WebSocket Hijacking vulnerability
 - targeted/cve-2021-22214.js > A targeted script to check for Unauthorised SSRF on GitLab - CVE 2021-22214
 - httpsender/full-session-n-csrf-nashorn.js > full session and csrf token management.
+- authentication/OfflineTokenRefresh.js - refresh oauth2 offline tokens
+- httpsender/AddBearerTokenHeader.js - refresh oauth2 offline tokens
 
 ### Changed
 - Update links in READMEs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
-
+- authentication/OfflineTokenRefresh.js - refresh oauth2 offline tokens
+- httpsender/AddBearerTokenHeader.js - refresh oauth2 offline tokens
 
 ## [11] - 2021-09-07
 ### Added
@@ -14,8 +15,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - httpfuzzerprocessor/unexpected_responses.js > compare response codes to a (pass/fail) regex and generate alerts
 - targeted/dns-email-spoofing > Check if DMARC / SPF policies are configured on a domain.
 - httpsender/add-more-headers.js > Add caller-specified headers to all requests.
-- authentication/OfflineTokenRefresh.js - refresh oauth2 offline tokens
-- httpsender/AddBearerTokenHeader.js - refresh oauth2 offline tokens
 
 ### Changed
 - Update links in READMEs.

--- a/authentication/OfflineTokenRefresh.js
+++ b/authentication/OfflineTokenRefresh.js
@@ -1,0 +1,74 @@
+/*
+* This script is intended to be used along with HTTP Sender/AddBearerTokenHeader.js to
+* handle an OAUTH2 offline token refresh workflow.
+*
+* Authentication/OfflineTokenRefresher.js will automatically fetch the new access token for every unauthorized
+* request determined by the "Logged Out" or "Logged In" indicator previously set in Context -> Authentication.
+*
+* HTTP Sender/AddBearerTokenHeader.js will add the new access token to all requests in scope
+* made by ZAP (except the authentication ones) as an "Authorization: Bearer [access_token]" HTTP Header.
+*
+*
+* @author Laura Pardo <lpardo at redhat.com>
+*
+*/
+
+var HttpRequestHeader = Java.type("org.parosproxy.paros.network.HttpRequestHeader");
+var HttpHeader = Java.type("org.parosproxy.paros.network.HttpHeader");
+var URI = Java.type("org.apache.commons.httpclient.URI");
+var ScriptVars = Java.type('org.zaproxy.zap.extension.script.ScriptVars');
+
+
+function authenticate(helper, paramsValues, credentials) {
+
+  var token_endpoint = paramsValues.get("token_endpoint");
+  var client_id = paramsValues.get("client_id");
+  var refresh_token = credentials.getParam("refresh_token");
+
+  // Build body
+  var refreshTokenBody = "client_id=" + client_id;
+  refreshTokenBody+= "&grant_type=refresh_token";
+  refreshTokenBody+= "&refresh_token=" + refresh_token;
+
+  // Build header
+  var tokenRequestURI = new URI(token_endpoint, false);
+  var tokenRequestMethod = HttpRequestHeader.POST;
+  var tokenRequestMainHeader = new HttpRequestHeader(tokenRequestMethod, tokenRequestURI, HttpHeader.HTTP11);
+
+  // Build message
+  var tokenMsg = helper.prepareMessage();
+  tokenMsg.setRequestBody(refreshTokenBody);
+  tokenMsg.setRequestHeader(tokenRequestMainHeader);
+  tokenMsg.getRequestHeader().setContentLength(tokenMsg.getRequestBody().length());
+
+  // Make the request and receive the response
+  helper.sendAndReceive(tokenMsg, false);
+
+  // Parse the JSON response and save the new access_token in a global var
+  // we will replace the Authentication header in AddBearerTokenHeader.js
+  var json = JSON.parse(tokenMsg.getResponseBody().toString());
+  var access_token = json['access_token'];
+
+  if (access_token){
+    ScriptVars.setGlobalVar("access_token", access_token);
+  }else{
+    print("Error getting access token")
+  }
+
+  return tokenMsg;
+}
+
+
+function getRequiredParamsNames(){
+  return ["token_endpoint", "client_id"];
+}
+
+
+function getOptionalParamsNames(){
+  return [];
+}
+
+
+function getCredentialsParamsNames(){
+  return ["access_token", "refresh_token"];
+}

--- a/authentication/OfflineTokenRefresh.js
+++ b/authentication/OfflineTokenRefresh.js
@@ -1,16 +1,14 @@
 /*
-* This script is intended to be used along with HTTP Sender/AddBearerTokenHeader.js to
+* This script is intended to be used along with  httpsender/AddBearerTokenHeader.js  to
 * handle an OAUTH2 offline token refresh workflow.
 *
-* Authentication/OfflineTokenRefresher.js will automatically fetch the new access token for every unauthorized
+* authentication/OfflineTokenRefresher.js will automatically fetch the new access token for every unauthorized
 * request determined by the "Logged Out" or "Logged In" indicator previously set in Context -> Authentication.
 *
-* HTTP Sender/AddBearerTokenHeader.js will add the new access token to all requests in scope
+*  httpsender/AddBearerTokenHeader.js  will add the new access token to all requests in scope
 * made by ZAP (except the authentication ones) as an "Authorization: Bearer [access_token]" HTTP Header.
 *
-*
 * @author Laura Pardo <lpardo at redhat.com>
-*
 */
 
 var HttpRequestHeader = Java.type("org.parosproxy.paros.network.HttpRequestHeader");

--- a/httpsender/AddBearerTokenHeader.js
+++ b/httpsender/AddBearerTokenHeader.js
@@ -1,16 +1,14 @@
 /*
-* This script is intended to be used along with Authentication/OfflineTokenRefresher.js to
+* This script is intended to be used along with authentication/OfflineTokenRefresher.js to
 * handle an OAUTH2 offline token refresh workflow.
 *
-* Authentication/OfflineTokenRefresher.js will automatically fetch the new access token for every unauthorized
+* authentication/OfflineTokenRefresher.js will automatically fetch the new access token for every unauthorized
 * request determined by the "Logged Out" or "Logged In" indicator previously set in Context -> Authentication.
 *
-* HTTP Sender/AddBearerTokenHeader.js will add the new access token to all requests in scope
+*  httpsender/AddBearerTokenHeader.js will add the new access token to all requests in scope
 * made by ZAP (except the authentication ones) as an "Authorization: Bearer [access_token]" HTTP Header.
 *
-*
 * @author Laura Pardo <lpardo at redhat.com>
-*
 */
 
 var HttpSender = Java.type('org.parosproxy.paros.network.HttpSender');

--- a/httpsender/AddBearerTokenHeader.js
+++ b/httpsender/AddBearerTokenHeader.js
@@ -1,0 +1,29 @@
+/*
+* This script is intended to be used along with Authentication/OfflineTokenRefresher.js to
+* handle an OAUTH2 offline token refresh workflow.
+*
+* Authentication/OfflineTokenRefresher.js will automatically fetch the new access token for every unauthorized
+* request determined by the "Logged Out" or "Logged In" indicator previously set in Context -> Authentication.
+*
+* HTTP Sender/AddBearerTokenHeader.js will add the new access token to all requests in scope
+* made by ZAP (except the authentication ones) as an "Authorization: Bearer [access_token]" HTTP Header.
+*
+*
+* @author Laura Pardo <lpardo at redhat.com>
+*
+*/
+
+var HttpSender = Java.type('org.parosproxy.paros.network.HttpSender');
+var ScriptVars = Java.type('org.zaproxy.zap.extension.script.ScriptVars');
+
+function sendingRequest(msg, initiator, helper) {
+
+  // add Authorization header to all request in scope except the authorization request itself
+  if (initiator !== HttpSender.AUTHENTICATION_INITIATOR && msg.isInScope()) {
+    msg.getRequestHeader().setHeader("Authorization", "Bearer " + ScriptVars.getGlobalVar("access_token"));
+  }
+
+  return msg;
+}
+
+function responseReceived(msg, initiator, helper) {}


### PR DESCRIPTION
This PR adds OAUTH2 offline token handle for ZAP users. 

* Authentication/OfflineTokenRefresher.js will automatically fetch the new access token for every unauthorized request determined by the "Logged Out" or "Logged In" indicator previously set in Context -> Authentication.

* HTTP Sender/AddBearerTokenHeader.js will add the new access token to all requests in scope made by ZAP (except the authentication ones) as an "Authorization: Bearer [access_token]" HTTP Header.