### PR TITLE
fix: cve-2021-41773-apache-path-trav.js set path escaped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
-
+### Fixed
+- targeted/cve-2021-41773-apache-path-trav.js - Set path as escaped so that it's handled properly, set pluginid properly.
 
 ## [12] - 2021-10-07
 ### Added

--- a/targeted/cve-2021-41773-apache-path-trav.js
+++ b/targeted/cve-2021-41773-apache-path-trav.js
@@ -40,7 +40,7 @@ function invokeWith(msg) {
     // To check if script is running
     logger("Testing Script against URL - " + url);
 
-    msg.getRequestHeader().getURI().setPath(attackPath);
+    msg.getRequestHeader().getURI().setEscapedPath(attackPath);
     var connectionParams = Model.getSingleton().getOptionsParam().getConnectionParam();
     var sender = new HttpSender(connectionParams, true, 6);
     sender.sendAndReceive(msg);
@@ -53,7 +53,6 @@ function invokeWith(msg) {
         re.lastIndex = 0
         var alertEvidence = re.exec(rebody);
         customAlert(
-            pluginid,
             3, // risk: 0: info, 1: low, 2: medium, 3: high
             3, // confidence: 0: falsePositive, 1: low, 2: medium, 3: high, 4: confirmed
             alertName,
@@ -75,11 +74,11 @@ function invokeWith(msg) {
  * Raise an alert.
  * @see https://www.javadoc.io/doc/org.zaproxy/zap/latest/org/parosproxy/paros/core/scanner/Alert.html
  */
-function customAlert(pluginid, alertRisk, alertConfidence, alertName, alertDesc, alertAttack, alertEvidence, alertSol, alertReference, cweId, wascId, msg, url) {
+function customAlert(alertRisk, alertConfidence, alertName, alertDesc, alertAttack, alertEvidence, alertSol, alertReference, cweId, wascId, msg, url) {
     var extensionAlert = Control.getSingleton().getExtensionLoader().getExtension(ExtensionAlert.NAME);
     var ref = new HistoryReference(session, HistoryReference.TYPE_ZAP_USER, msg);
 
-    var alert = new org.parosproxy.paros.core.scanner.Alert(pluginid, alertRisk, alertConfidence, alertName);
+    var alert = new org.parosproxy.paros.core.scanner.Alert(-1, alertRisk, alertConfidence, alertName);
     alert.setDescription(alertDesc);
     alert.setAttack(alertAttack);
     alert.setEvidence(alertEvidence);


### PR DESCRIPTION
- Tweak targeted script, set the path as escaped so that things are further encoded making it fail. Remove undefined pluginid, use -1.
- Add changelog note.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>