### PR TITLE
Check for the version in Server Header Disclosure 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - standalone/enableDebugLogging.js > Updated for more recent logging funtionality.
 - Update JS scripts to use passed singleton variables (control, model, view) if available (>= ZAP 2.12.0).
+- passive/Server Header Disclosure.js > Updated to check that the Server Header contains something that looks like a semantic version component.
 
 ## [14] - 2021-11-01
 ### Added

--- a/passive/Server Header Disclosure.js
+++ b/passive/Server Header Disclosure.js
@@ -1,7 +1,9 @@
 // Server Header Check by freakyclown@gmail.com
+// Server Version leaks found via header field by prateek.rana@getastra.com
 
-function scan(ps, msg, src) 
-{
+var VERSION_PATTERN = new RegExp("(?:\\d+\\.)+\\d+");
+
+function scan(ps, msg, src)  {
 
     var alertRisk = 1
     var alertConfidence = 2
@@ -15,9 +17,24 @@ function scan(ps, msg, src)
     var url = msg.getRequestHeader().getURI().toString();
     var headers = msg.getResponseHeader().getHeaders("Server")
     
-    if (headers != null)
+    if (headers != null && containsPotentialSemver(headers))
     {
-        ps.raiseAlert(alertRisk, alertConfidence, alertTitle, alertDesc, url, '', '', '', alertSolution,headers, cweId, wascId, msg);
+        var headersString = headers.toString();
+        ps.raiseAlert(alertRisk, alertConfidence, alertTitle, alertDesc, url, '', '', '', alertSolution, headersString, cweId, wascId, msg);
     }
     
+}
+
+function containsPotentialSemver(content) {
+    try {
+        var res = VERSION_PATTERN.exec(content);
+        if (res == null || res.join('') === ""){
+            return false;
+        }
+        return true;
+    }
+
+    catch (err) {
+        return false;
+    }
 }


### PR DESCRIPTION
The Alert Description states about leaking version information via the http header. The previous version for the script only checks for the header without considering whether even the version is leaked or not. Added checks for looking up numeric versions information available in the http header. 