### PR TITLE
Check for the version in X-Powered-By header disclosure

### DIFF
--- a/passive/Server Header Disclosure.js
+++ b/passive/Server Header Disclosure.js
@@ -1,5 +1,5 @@
 // Server Header Check by freakyclown@gmail.com
-// Server Version leaks found via header field by prateek.rana@getastra.com
+// Server Version leak via header field by prateek.rana@getastra.com
 
 function scan(ps, msg, src) 
 {

--- a/passive/Server Header Disclosure.js
+++ b/passive/Server Header Disclosure.js
@@ -1,4 +1,5 @@
 // Server Header Check by freakyclown@gmail.com
+// Server Version leak via header field by prateek.rana@getastra.com
 
 function scan(ps, msg, src) 
 {
@@ -14,10 +15,38 @@ function scan(ps, msg, src)
 
     var url = msg.getRequestHeader().getURI().toString();
     var headers = msg.getResponseHeader().getHeaders("Server")
+    var headers_string = headers.toString();
     
-    if (headers != null)
+    if (headers != null && ExtAlert(headers))
     {
-        ps.raiseAlert(alertRisk, alertConfidence, alertTitle, alertDesc, url, '', '', '', alertSolution,headers, cweId, wascId, msg);
+        ps.raiseAlert(alertRisk, alertConfidence, alertTitle, alertDesc, url, '', '', '', alertSolution, headers_string, cweId, wascId, msg);
     }
     
+}
+
+function ExtAlert(content) {
+
+    var ext = new RegExp("(\\d+\\.)+\\d+");
+
+    try {
+        var res = ext.exec(content);
+        if (res == null){
+            return false;
+        }
+        res = res.join('');
+
+        if (res === "") {
+            return false;
+        }
+        
+        else {
+            print("Server version leak found via header.");
+            return true;        
+        }
+    }
+
+    catch (err) {
+        print(err);
+        return false;
+    }
 }

--- a/passive/Server Header Disclosure.js
+++ b/passive/Server Header Disclosure.js
@@ -1,5 +1,5 @@
 // Server Header Check by freakyclown@gmail.com
-// Server Version leak via header field by prateek.rana@getastra.com
+// Server Version leaks found via header field by prateek.rana@getastra.com
 
 function scan(ps, msg, src) 
 {

--- a/passive/Server Header Disclosure.js
+++ b/passive/Server Header Disclosure.js
@@ -1,5 +1,4 @@
 // Server Header Check by freakyclown@gmail.com
-// Server Version leak via header field by prateek.rana@getastra.com
 
 function scan(ps, msg, src) 
 {
@@ -15,38 +14,10 @@ function scan(ps, msg, src)
 
     var url = msg.getRequestHeader().getURI().toString();
     var headers = msg.getResponseHeader().getHeaders("Server")
-    var headers_string = headers.toString();
     
-    if (headers != null && ExtAlert(headers))
+    if (headers != null)
     {
-        ps.raiseAlert(alertRisk, alertConfidence, alertTitle, alertDesc, url, '', '', '', alertSolution, headers_string, cweId, wascId, msg);
+        ps.raiseAlert(alertRisk, alertConfidence, alertTitle, alertDesc, url, '', '', '', alertSolution,headers, cweId, wascId, msg);
     }
     
-}
-
-function ExtAlert(content) {
-
-    var ext = new RegExp("(\\d+\\.)+\\d+");
-
-    try {
-        var res = ext.exec(content);
-        if (res == null){
-            return false;
-        }
-        res = res.join('');
-
-        if (res === "") {
-            return false;
-        }
-        
-        else {
-            print("Server version leak found via header.");
-            return true;        
-        }
-    }
-
-    catch (err) {
-        print(err);
-        return false;
-    }
 }

--- a/passive/X-Powered-By_header_checker.js
+++ b/passive/X-Powered-By_header_checker.js
@@ -1,4 +1,6 @@
 // X-Powered-By finder by freakyclown@gmail.com
+// Server Version leaks found via X-Powered-By header field by prateek.rana@getastra.com
+
 
 function scan(ps, msg, src) 
 {
@@ -14,10 +16,38 @@ function scan(ps, msg, src)
 
     var url = msg.getRequestHeader().getURI().toString();
     var headers = msg.getResponseHeader().getHeaders("X-Powered-By")
+    var headers_string = headers.toString();
     
-    if (headers != null)
+     if (headers != null && ExtAlert(headers))
     {
-        ps.raiseAlert(alertRisk, alertConfidence, alertTitle, alertDesc, url, '', '', '', alertSolution,headers, cweId, wascId, msg);
+        ps.raiseAlert(alertRisk, alertConfidence, alertTitle, alertDesc, url, '', '', '', alertSolution, headers_string, cweId, wascId, msg);
     }
     
+}
+
+function ExtAlert(content) {
+
+    var ext = new RegExp("(\\d+\\.)+\\d+");
+
+    try {
+        var res = ext.exec(content);
+        if (res == null){
+            return false;
+        }
+        res = res.join('');
+
+        if (res === "") {
+            return false;
+        }
+        
+        else {
+            print("Server version leak found via X-Powered-By header.");
+            return true;        
+        }
+    }
+
+    catch (err) {
+        print(err);
+        return false;
+    }
 }


### PR DESCRIPTION
The Alert Description states about leaking version information via the X-Powered-By header. The previous version for the script only checks for the X-Powered-By header without considering whether even the version is leaked or not. Added checks for looking up numeric versions information available in the header.