### PR TITLE
Remove misleading statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
-
+### Changed
+- Remove statements that return the message in HTTP Sender scripts, the message passed as parameter is used/sent always.
 
 ## [16] - 2023-03-29
 ### Added

--- a/httpsender/AddBearerTokenHeader.js
+++ b/httpsender/AddBearerTokenHeader.js
@@ -20,8 +20,6 @@ function sendingRequest(msg, initiator, helper) {
   if (initiator !== HttpSender.AUTHENTICATION_INITIATOR && msg.isInScope()) {
     msg.getRequestHeader().setHeader("Authorization", "Bearer " + ScriptVars.getGlobalVar("access_token"));
   }
-
-  return msg;
 }
 
 function responseReceived(msg, initiator, helper) {}

--- a/httpsender/add-extra-headers.js
+++ b/httpsender/add-extra-headers.js
@@ -36,7 +36,7 @@ var ignoreHeader = [
 function sendingRequest(msg, initiator, helper) {
   if (initiator === HttpSender.AUTHENTICATION_INITIATOR) {
     logger("Trying to auth")
-    return msg;
+    return;
   }
   var hostname = msg.getRequestHeader().getHostName()
   var varKey = "headers-" + hostname
@@ -81,7 +81,6 @@ function sendingRequest(msg, initiator, helper) {
        msg.getRequestHeader().setHeader(key, extras[key]);
      }
   }
-  return msg;
 }
 
 function responseReceived(msg, initiator, helper) {}

--- a/httpsender/add-more-headers.js
+++ b/httpsender/add-more-headers.js
@@ -55,8 +55,6 @@ function sendingRequest(msg, initiator, helper) {
         // logger("Setting " + key + " to " + value);
         msg.getRequestHeader().setHeader(key, value);
     }
-
-	return msg;
 }
 
 /* Called after receiving the response from the server.

--- a/httpsender/maintain-jwt.js
+++ b/httpsender/maintain-jwt.js
@@ -16,7 +16,7 @@ var COOKIE_TYPE   = org.parosproxy.paros.network.HtmlParameter.Type.cookie;
 function sendingRequest(msg, initiator, helper) {
   if (initiator === HttpSender.AUTHENTICATION_INITIATOR) {
     logger("Trying to auth")
-  return msg;
+    return;
   }
 
   var token = ScriptVars.getGlobalVar("jwt-token")
@@ -26,7 +26,6 @@ function sendingRequest(msg, initiator, helper) {
   // For all non-authentication requests we want to include the authorization header
   logger("Added authorization token " + token.slice(0, 20) + " ... ")
   msg.getRequestHeader().setHeader('Authorization', 'Bearer ' + token);
-  return msg;
 }
 
 function responseReceived(msg, initiator, helper) {


### PR DESCRIPTION
Remove statements that return the message in HTTP Sender scripts, the message passed as parameter is used/sent regardless if it's returned or not.