### PR TITLE
Update ZAP to 2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 ### Changed
+- Update minimum ZAP version to 2.12.0:
+  - Remove compatibility code that provided the singletons (`control` and `model`) in JavaScript scripts, they can now be accessed directly always.
+  - Use provided singletons (`control` and `model`) in Python scripts.
+  - Use non-deprecated `HttpSender` constructor.
 - Remove statements that return the message in HTTP Sender scripts, the message passed as parameter is used/sent always.
 
 ## [16] - 2023-03-29

--- a/af-plans/juiceshop-selenium-auth/JuiceShopAuthentication.js
+++ b/af-plans/juiceshop-selenium-auth/JuiceShopAuthentication.js
@@ -72,8 +72,7 @@ function authenticate(helper, _paramsValues, _credentials) {
 	}
 
 	logger("Launching browser to authenticate to Juice Shop");
-	var extSel = control.getSingleton().
-		getExtensionLoader().getExtension(
+	var extSel = control.getExtensionLoader().getExtension(
 			org.zaproxy.zap.extension.selenium.ExtensionSelenium.class);
 
 	// Change to "firefox" (or "chrome") to see the browsers being launched

--- a/af-plans/juiceshop-selenium-auth/JuiceShopReset.js
+++ b/af-plans/juiceshop-selenium-auth/JuiceShopReset.js
@@ -32,8 +32,7 @@ if (token) {
 }
 
 // Reset the state for all users
-var extUser = control.getSingleton().
-	getExtensionLoader().getExtension(
+var extUser = control.getExtensionLoader().getExtension(
 		org.zaproxy.zap.extension.users.ExtensionUserManagement.class);
 var session = model.getSession();
 var contexts = session.getContexts();

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ val scriptsDir = layout.buildDirectory.dir("scripts")
 zapAddOn {
     addOnId.set("communityScripts")
     addOnName.set("Community Scripts")
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.12.0")
     addOnStatus.set(AddOnStatus.ALPHA)
 
     releaseLink.set("https://github.com/zaproxy/community-scripts/compare/v@PREVIOUS_VERSION@...v@CURRENT_VERSION@")

--- a/extender/Simple Reverse Proxy.js
+++ b/extender/Simple Reverse Proxy.js
@@ -1,9 +1,4 @@
 // An extender script that adds a simple reverse proxy.
-// Requires a ZAP version greater than 2.7.0.
-
-var control, model
-if (!control) control = Java.type("org.parosproxy.paros.control.Control").getSingleton()
-if (!model) model = Java.type("org.parosproxy.paros.model.Model").getSingleton()
 
 // To where the requests are sent.
 var remoteAddress = "example.com"

--- a/httpfuzzerprocessor/add_msgs_sites_tree.js
+++ b/httpfuzzerprocessor/add_msgs_sites_tree.js
@@ -2,9 +2,6 @@
 // with messages sent by the fuzzer (by default the fuzz result/messages
 // are not shown in the Fuzzer tab).
 
-var model;
-if (!model) model = Java.type("org.parosproxy.paros.model.Model").getSingleton();
-
 var session = model.getSession();
 
 function processMessage(utils, message) {}

--- a/httpsender/Alert on HTTP Response Code Errors.js
+++ b/httpsender/Alert on HTTP Response Code Errors.js
@@ -2,10 +2,6 @@
 // By default it will raise 'Info' level alerts for Client Errors (4xx) (apart from 404s) and 'Low' Level alerts for Server Errors (5xx)
 // But it can be easily changed.
 
-var control, model
-if (!control) control = Java.type("org.parosproxy.paros.control.Control").getSingleton()
-if (!model) model = Java.type("org.parosproxy.paros.model.Model").getSingleton()
-
 var Pattern = Java.type("java.util.regex.Pattern")
 pluginid = 100000	// https://github.com/zaproxy/zaproxy/blob/main/docs/scanners.md
 

--- a/httpsender/Alert on Unexpected Content Types.js
+++ b/httpsender/Alert on Unexpected Content Types.js
@@ -2,10 +2,6 @@
 // By default it will raise 'Low' level alerts for content types that are not expected to be returned by APIs.
 // But it can be easily changed.
 
-var control, model
-if (!control) control = Java.type("org.parosproxy.paros.control.Control").getSingleton()
-if (!model) model = Java.type("org.parosproxy.paros.model.Model").getSingleton()
-
 var Pattern = Java.type("java.util.regex.Pattern")
 
 var pluginid = 100001	// https://github.com/zaproxy/zaproxy/blob/main/docs/scanners.md

--- a/standalone/Active scan rule list.js
+++ b/standalone/Active scan rule list.js
@@ -1,8 +1,5 @@
 // This script gives details about all of the active scan rules installed
 
-var control;
-if (!control) control = Java.type("org.parosproxy.paros.control.Control").getSingleton();
-
 extAscan = control.getExtensionLoader().getExtension(
     org.zaproxy.zap.extension.ascan.ExtensionActiveScan.NAME);
 

--- a/standalone/Juice shop authentication by form.js
+++ b/standalone/Juice shop authentication by form.js
@@ -4,9 +4,6 @@
 // a user with a name of test@test.com and a password of test123
 // You can change any of the variables to match your environment if needed.
 
-var control;
-if (!control) control = Java.type("org.parosproxy.paros.control.Control").getSingleton();
-
 var By = Java.type('org.openqa.selenium.By');
 var Thread = Java.type('java.lang.Thread');
 var juiceshop = 'http://localhost:3000/';

--- a/standalone/Juice shop authentication by google.js
+++ b/standalone/Juice shop authentication by google.js
@@ -3,9 +3,6 @@
 // Juice Shop will need to be accessible via http://localhost:3000/ and you will need to change the 
 // username and password to match a valid Google account.
 
-var control
-if (!control) control = Java.type("org.parosproxy.paros.control.Control").getSingleton()
-
 var By = Java.type('org.openqa.selenium.By');
 var Thread = Java.type('java.lang.Thread');
 var juiceshop = 'http://localhost:3000/';

--- a/standalone/Loop through alerts.js
+++ b/standalone/Loop through alerts.js
@@ -2,9 +2,6 @@
 //
 // This is a standalone script which you can run from the Script Console
 
-var control
-if (!control) control = Java.type("org.parosproxy.paros.control.Control").getSingleton()
-
 extAlert = control.getExtensionLoader().getExtension(
         org.zaproxy.zap.extension.alert.ExtensionAlert.NAME) 
 if (extAlert != null) {

--- a/standalone/Loop through history table.js
+++ b/standalone/Loop through history table.js
@@ -3,9 +3,6 @@
 // Standalone scripts have no template.
 // They are only evaluated when you run them. 
 
-var control
-if (!control) control = Java.type("org.parosproxy.paros.control.Control").getSingleton()
-
 extHist = control.getExtensionLoader().getExtension(
     org.parosproxy.paros.extension.history.ExtensionHistory.NAME) 
 if (extHist != null) {

--- a/standalone/SecurityCrawlMazeScore.js
+++ b/standalone/SecurityCrawlMazeScore.js
@@ -2,9 +2,6 @@
 //
 // You will need to have run one or both of the ZAP spiders against https://security-crawl-maze.app/
 
-var model
-if (!model) model = Java.type("org.parosproxy.paros.model.Model").getSingleton()
-
 // Expected results sourced from:
 // https://raw.githubusercontent.com/google/security-crawl-maze/master/blueprints/utils/resources/expected-results.json
 

--- a/standalone/Traverse sites tree.js
+++ b/standalone/Traverse sites tree.js
@@ -3,9 +3,6 @@
 // Standalone scripts have no template.
 // They are only evaluated when you run them. 
 
-var model
-if (!model) model = Java.type("org.parosproxy.paros.model.Model").getSingleton()
-
 function listChildren(node, level) {
     var j;
     for (j=0;j<node.getChildCount();j++) {

--- a/standalone/WebSocketExportToOrg.py
+++ b/standalone/WebSocketExportToOrg.py
@@ -48,7 +48,7 @@ import binascii
 reload(sys)
 sys.setdefaultencoding('utf-8')
 
-extWebSocket = Control.getSingleton().getExtensionLoader().getExtension(ExtensionWebSocket.NAME)
+extWebSocket = control.getExtensionLoader().getExtension(ExtensionWebSocket.NAME)
 pathToOrgFile = "/path/to/file.org"
 printSummary = True
 base = PyOrgMode.OrgDataStructure()

--- a/standalone/alertAndPluginDetails.js
+++ b/standalone/alertAndPluginDetails.js
@@ -5,9 +5,6 @@
  * It's tab separated so you can simply copy/paste it into Excel (or whatever).
  */
 
-var control
-if (!control) control = Java.type("org.parosproxy.paros.control.Control").getSingleton()
-
 extAlert = control.getExtensionLoader().getExtension(
     org.zaproxy.zap.extension.alert.ExtensionAlert.NAME) 
 

--- a/standalone/extHistoryEnumerator.py
+++ b/standalone/extHistoryEnumerator.py
@@ -11,8 +11,8 @@ import re;
 from org.parosproxy.paros.view import AbstractFrame;
 from org.zaproxy.zap.utils import ZapTextArea;
 
-sessionId = Model.getSingleton().getSession();
-tbHist = Model.getSingleton().getDb().getTableHistory();
+sessionId = model.getSession();
+tbHist = model.getDb().getTableHistory();
 
 """ Change this variable to match the expression you are looking for """
 regex='soapactio.+';

--- a/standalone/historySourceTagger.js
+++ b/standalone/historySourceTagger.js
@@ -6,9 +6,6 @@
 // Author: kingthorin+owaspzap@gmail.com
 // 20160207: Initial release
 
-var control, model
-if (!control) control = Java.type("org.parosproxy.paros.control.Control").getSingleton()
-
 extHist = control.getExtensionLoader().
     getExtension(org.parosproxy.paros.extension.history.ExtensionHistory.NAME);
 

--- a/standalone/load_context_from_burp.py
+++ b/standalone/load_context_from_burp.py
@@ -78,7 +78,7 @@ def build_proper_regex(protocol, host):
 
 
 def create_new_context(ctx_name):
-    session = Model().getSingleton().getSession()
+    session = model.getSession()
     new_context = session.getNewContext(ctx_name)
     return new_context
 

--- a/standalone/past_cookies_jar.py
+++ b/standalone/past_cookies_jar.py
@@ -14,8 +14,8 @@ from javax.swing import JScrollPane;
 """ Change this regex to match the desired domain """
 cookie_domain_regex = ".+"
 
-sessionId = Model.getSingleton().getSession();
-tbHist = Model.getSingleton().getDb().getTableHistory();
+sessionId = model.getSession();
+tbHist = model.getDb().getTableHistory();
 
 def collect(msg):
   """ Collecting cookie from HttpMessage """

--- a/standalone/scan_rule_list.js
+++ b/standalone/scan_rule_list.js
@@ -1,8 +1,5 @@
 // This script gives details about all of the scan rules installed
 
-var control, model
-if (!control) control = Java.type("org.parosproxy.paros.control.Control").getSingleton()
-
 extAscan = control.getExtensionLoader().getExtension(
         org.zaproxy.zap.extension.ascan.ExtensionActiveScan.NAME);
 

--- a/targeted/ElasticSearchExploit.js
+++ b/targeted/ElasticSearchExploit.js
@@ -4,8 +4,7 @@
 // Shoutout to /u/cartogram for the POC rce command
 // Requires elasticsearch running, default port is 9200 check via nmap/portscanner
 
-var model
-if (!model) model = Java.type("org.parosproxy.paros.model.Model").getSingleton()
+var HttpSender = Java.type("org.parosproxy.paros.network.HttpSender")
 
 function invokeWith(msg) {
 	// give the user some info
@@ -27,7 +26,7 @@ function invokeWith(msg) {
 	// update the length to take in account of the changes
 	msg.getRequestHeader().setContentLength(msg.getRequestBody().length());
 	// create a new sender
-	var sender = new org.parosproxy.paros.network.HttpSender(model.getOptionsParam().getConnectionParam(), true, 6)
+	var sender = new HttpSender(HttpSender.MANUAL_REQUEST_INITIATOR)
 	// send our new request
 	sender.sendAndReceive(msg)
 		

--- a/targeted/Find largest subtree.js
+++ b/targeted/Find largest subtree.js
@@ -6,9 +6,6 @@ tot = 0
 maxparent = ""
 maxsub = 0
 
-var model
-if (!model) model = Java.type("org.parosproxy.paros.model.Model").getSingleton()
-
 function recurseDown(node) {
 	//print('recurseDown node: ' + node.getHierarchicNodeName() + " " + node.getChildCount())
 	tot++

--- a/targeted/Remove 302s.js
+++ b/targeted/Remove 302s.js
@@ -3,9 +3,6 @@
 // The default criteria is leaf nodes with a response code of 302 but you can change that to anything you need
 // Targeted scripts can only be invoked by you, the user, eg via a right-click option on the Sites or History tabs
 
-var model
-if (!model) model = Java.type("org.parosproxy.paros.model.Model").getSingleton()
-
 function recurseDown(sitestree, node) {
 	//print('recurseDown node: ' + node.getHierarchicNodeName() + " " + node.getChildCount())
 	// Loop down through the children first

--- a/targeted/WordPress User Enumeration.js
+++ b/targeted/WordPress User Enumeration.js
@@ -5,10 +5,6 @@
 
 var pluginid = 100032;
 
-var control, model
-if (!control) control = Java.type("org.parosproxy.paros.control.Control").getSingleton()
-if (!model) model = Java.type("org.parosproxy.paros.model.Model").getSingleton() 
-
 var URI = Java.type("org.apache.commons.httpclient.URI");
 var HttpSender = Java.type("org.parosproxy.paros.network.HttpSender");
 var HistoryReference = Java.type("org.parosproxy.paros.model.HistoryReference");
@@ -16,7 +12,6 @@ var ExtensionAlert = Java.type("org.zaproxy.zap.extension.alert.ExtensionAlert")
 var Alert = Java.type("org.parosproxy.paros.core.scanner.Alert");
 
 var session = model.getSession();
-var connectionParams = model.getOptionsParam().getConnectionParam();
 var extLoader = control.getExtensionLoader();
 
 // Print statements using script name
@@ -155,7 +150,7 @@ function sendReq(msg, query) {
     isNaN(query) ? uri.setPath(query) : uri.setQuery("author=" + query);
     logger("URL -> " + uri.toString());
     // Initialise the sender
-    var sender = new HttpSender(connectionParams, true, 6);
+    var sender = new HttpSender(HttpSender.MANUAL_REQUEST_INITIATOR);
     // Send and Receive Request
     sender.sendAndReceive(newReq);
     // Debugging

--- a/targeted/cve-2021-22214.js
+++ b/targeted/cve-2021-22214.js
@@ -5,10 +5,6 @@
 
 var pluginid = 100024;
 
-var control, model
-if (!control) control = Java.type("org.parosproxy.paros.control.Control").getSingleton()
-if (!model) model = Java.type("org.parosproxy.paros.model.Model").getSingleton()
-
 var HttpSender = Java.type("org.parosproxy.paros.network.HttpSender")
 var HistoryReference = Java.type("org.parosproxy.paros.model.HistoryReference")
 var HttpHeader = Java.type("org.parosproxy.paros.network.HttpHeader")
@@ -88,7 +84,7 @@ function invokeWith(msg) {
  */
 function sendReq(msg) {
     var newReq = generateRequest(msg);
-    var sender = new HttpSender(model.getOptionsParam().getConnectionParam(), true, 6)
+    var sender = new HttpSender(HttpSender.MANUAL_REQUEST_INITIATOR)
     sender.sendAndReceive(newReq);
     // Debugging
     // logger("Request Header -> " + newReq.getRequestHeader().toString())

--- a/targeted/cve-2021-41773-apache-path-trav.js
+++ b/targeted/cve-2021-41773-apache-path-trav.js
@@ -3,10 +3,6 @@
  * Based on: https://github.com/RootUp/PersonalStuff/blob/master/http-vuln-cve-2021-41773.nse
  */
 
-var control, model
-if (!control) control = Java.type("org.parosproxy.paros.control.Control").getSingleton()
-if (!model) model = Java.type("org.parosproxy.paros.model.Model").getSingleton() 
-
 var HttpSender = Java.type("org.parosproxy.paros.network.HttpSender")
 var HistoryReference = Java.type("org.parosproxy.paros.model.HistoryReference")
 var HttpHeader = Java.type("org.parosproxy.paros.network.HttpHeader")
@@ -43,8 +39,7 @@ function invokeWith(msg) {
     logger("Testing Script against URL - " + url);
 
     msg.getRequestHeader().getURI().setEscapedPath(attackPath);
-    var connectionParams = model.getOptionsParam().getConnectionParam();
-    var sender = new HttpSender(connectionParams, true, 6);
+    var sender = new HttpSender(HttpSender.MANUAL_REQUEST_INITIATOR);
     sender.sendAndReceive(msg);
     var status = msg.getResponseHeader().getStatusCode();
     var rebody = msg.getResponseBody().toString();

--- a/targeted/dns-email-spoofing.js
+++ b/targeted/dns-email-spoofing.js
@@ -5,10 +5,6 @@
 var pluginid = 100031;
 var providerAddress = "dns.google";
 
-var control, model
-if (!control) control = Java.type("org.parosproxy.paros.control.Control").getSingleton()
-if (!model) model = Java.type("org.parosproxy.paros.model.Model").getSingleton()
-
 var URI = Java.type("org.apache.commons.httpclient.URI");
 var HttpSender = Java.type("org.parosproxy.paros.network.HttpSender");
 var HistoryReference = Java.type("org.parosproxy.paros.model.HistoryReference");
@@ -16,7 +12,6 @@ var ExtensionAlert = Java.type("org.zaproxy.zap.extension.alert.ExtensionAlert")
 var Alert = Java.type("org.parosproxy.paros.core.scanner.Alert");
 
 var session = model.getSession();
-var connectionParams = model.getOptionsParam().getConnectionParam();
 var extLoader = control.getExtensionLoader();
 
 // Print statements using script name
@@ -121,7 +116,7 @@ function fetchRecords(msg, policy) {
     msg.getRequestHeader().setURI(requestUri);
     logger("Fetching TXT records for domain - " + domain);
 
-    var sender = new HttpSender(connectionParams, true, 6);
+    var sender = new HttpSender(HttpSender.MANUAL_REQUEST_INITIATOR);
     sender.sendAndReceive(msg);
     // Debugging
     // logger("Request Header -> " + msg.getRequestHeader().toString())


### PR DESCRIPTION
Remove compatibility code that's no longer needed, that provided singletons.
Use provided singletons (`control` and `model`) in Python scripts.
Use non-deprecated `HttpSender` constructor and use constant instead of the literal for the initiator value (clearer).