### PR TITLE
Update script engines and other test dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,22 +48,22 @@ crowdin {
     }
 }
 
-val jupiterVersion = "5.9.2"
+val jupiterVersion = "5.9.3"
 
 dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api:$jupiterVersion")
     testImplementation("org.junit.jupiter:junit-jupiter-params:$jupiterVersion")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$jupiterVersion")
 
-    testImplementation("commons-io:commons-io:2.11.0")
+    testImplementation("commons-io:commons-io:2.13.0")
     testImplementation("org.assertj:assertj-core:3.24.2")
     testImplementation("org.apache.commons:commons-lang3:3.12.0")
 
     // The following versions should match the ones of the add-ons.
-    testImplementation("org.codehaus.groovy:groovy-all:2.4.14")
+    testImplementation("org.codehaus.groovy:groovy-all:3.0.14")
     testImplementation("org.jruby:jruby-complete:1.7.4")
-    testImplementation("org.mozilla:zest:0.14.0")
-    testImplementation("org.python:jython-standalone:2.7.1")
+    testImplementation("org.zaproxy:zest:0.18.0")
+    testImplementation("org.python:jython-standalone:2.7.2")
 }
 
 tasks.withType<JavaCompile>().configureEach {

--- a/src/test/java/org/zaproxy/VerifyScripts.java
+++ b/src/test/java/org/zaproxy/VerifyScripts.java
@@ -55,10 +55,10 @@ import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mozilla.zest.core.v1.ZestJSON;
-import org.mozilla.zest.core.v1.ZestScript;
 import org.python.core.Options;
 import org.python.jsr223.PyScriptEngineFactory;
+import org.zaproxy.zest.core.v1.ZestJSON;
+import org.zaproxy.zest.core.v1.ZestScript;
 
 /** Verifies that the scripts are parsed without errors. */
 class VerifyScripts {


### PR DESCRIPTION
Update the script engines to match the latest versions in the script add-ons, update imports in tests accordingly.
Update other test dependencies.