### PR TITLE
Update Docker images, docs, and scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update minimum ZAP version to 2.13.0.
 - Remove checks for CFU initiator in HTTP Sender scripts and docs, no longer needed.
+- Rename AWS signing script.
+- Update descriptions/comments in scripts.
 
 ## [17] - 2023-06-28
 ### Added

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -10,7 +10,7 @@ will create the tag, create the release, trigger the update of the marketplace, 
 
 ## Localized Resources
 
-The resources that require localization (e.g. `Messages.properties`, help pages) are uploaded to the OWASP ZAP projects in
+The resources that require localization (e.g. `Messages.properties`, help pages) are uploaded to the ZAP projects in
 [Crowdin](https://crowdin.com/) when the add-on is released, if required (for pre-translation) the resources can be uploaded manually at anytime
 by running the workflow [Crowdin Upload Files](https://github.com/zaproxy/community-scripts/actions/workflows/crowdin-upload-files.yml).
 

--- a/authentication/TwoStepAuthentication.js
+++ b/authentication/TwoStepAuthentication.js
@@ -1,4 +1,4 @@
-// Author : aine-rb from Sopra Steria (based on the script of thc202 from the OWASP ZAP development team)
+// Author : aine-rb from Sopra Steria
 
 // This script is heavily based on the "Simple Form-Based Authentication.js" template
 // It can be used to authenticate in a webapplication via a form submission followed by a GET request

--- a/httpsender/aws-signing-for-zap.py
+++ b/httpsender/aws-signing-for-zap.py
@@ -1,4 +1,4 @@
-# AWS Signing Script for OWASP Zed Attack Proxy - ZAP
+# AWS Signing Script for Zed Attack Proxy - ZAP
 # HelpAddOn Script - HTTPSender
 # Ismael Goncalves - https://sharingsec.blogspot.com
 # https://github.com/irgoncalves

--- a/other/api/mass-baseline/docker-wrapper
+++ b/other/api/mass-baseline/docker-wrapper
@@ -1,5 +1,5 @@
 # This dockerfile builds the Mass Baseline wrapper around the ZAP weekly release
-FROM owasp/zap2docker-weekly
+FROM ghcr.io/zaproxy/zaproxy:weekly
 MAINTAINER Simon Bennetts "psiinon@gmail.com"
 
 USER zap

--- a/other/scan-hooks/LogMessagesHook.py
+++ b/other/scan-hooks/LogMessagesHook.py
@@ -1,7 +1,7 @@
 # A scan hook (https://www.zaproxy.org/docs/docker/scan-hooks/) which adds a script for logging all requests.
 # To use this script copy it and the httpsender/LogRequests.js script to your CWD.
 # Then run ZAP like this:
-#     docker run -v $(pwd):/zap/wrk/:rw -t owasp/zap2docker-stable zap-baseline.py -t https://www.example.com --hook=LogMessagesHook.py
+#     docker run -v $(pwd):/zap/wrk/:rw -t ghcr.io/zaproxy/zaproxy:stable zap-baseline.py -t https://www.example.com --hook=LogMessagesHook.py
 # The requests and responses should be written to a req-resp-log.txt file in the CWD.
 
 def zap_started(zap, target):

--- a/other/scan-hooks/dynatrace/DynatraceHooks.py
+++ b/other/scan-hooks/dynatrace/DynatraceHooks.py
@@ -2,7 +2,7 @@ import os
 from sre_compile import isstring
 import requests
 
-# Custom Hook to integrate Dynatrace with OWASP ZAP
+# Custom Hook to integrate Dynatrace with ZAP
 #
 # This integration will:
 # - Configure log attributes, log metrics and log events in DT
@@ -27,7 +27,7 @@ import requests
 # -e dt_api_token="dt0c01.*********" ^
 # -e dt_entity_selector="type(APPLICATION),entityName.equals(PROD - example.com)" ^
 # -e dt_create_config="true" ^
-# -t owasp/zap2docker-stable zap-baseline.py ^
+# -t ghcr.io/zaproxy/zaproxy:stable zap-baseline.py ^
 # -t https://example.com ^
 # --hook=DynatraceHooks.py
 #
@@ -38,7 +38,7 @@ import requests
 # -e dt_api_token="dt0c01.*********" \
 # -e dt_entity_selector="type(APPLICATION),entityName.equals(PROD - example.com)" \
 # -e dt_create_config="true" \
-# -t owasp/zap2docker-stable zap-baseline.py \
+# -t ghcr.io/zaproxy/zaproxy:stable zap-baseline.py \
 # -t https://example.com \
 # --hook=DynatraceHooks.py
 #

--- a/passive/Find IBANs.js
+++ b/passive/Find IBANs.js
@@ -3,7 +3,7 @@
 // Regex evaluated at https://regexr.com/4kb6e
 // Tested against sample vulnerable page https://neverwind.azurewebsites.net/Admin/Download/Get
 // Runs as a part of nightly baseline scans in many DevSecOps environments
-// Complements the Pluralsight course - Writing Custom Scripts for OWASP Zed Attack Proxy
+// Complements the Pluralsight course - Writing Custom Scripts for Zed Attack Proxy
 
 function scan(ps, msg, src) {
     // first lets set up some details incase we find an IBAN, these will populate the alert later


### PR DESCRIPTION
Use Docker images from GHCR.
Remove OWASP references from docs and scripts.
Remove unnecessary attribution.