### PR TITLE
Require newer Python ZAP API client

### DIFF
--- a/other/api/sdlc-integration/requirements.txt
+++ b/other/api/sdlc-integration/requirements.txt
@@ -1,2 +1,2 @@
-python-owasp-zap-v2.4
+zaproxy
 requests


### PR DESCRIPTION
Require `zaproxy` instead of `python-owasp-zap-v2.4`, the latter was renamed to the former.