### PR TITLE
Simplify/remove my authorship notes

### DIFF
--- a/active/gof_lite.js
+++ b/active/gof_lite.js
@@ -14,7 +14,7 @@
 // available as: http://example.com/index.html.bak
 //
 // gof_lite.js
-// Author: kingthorin+owaspzap@gmail.com
+// Author: kingthorin
 // 20150828 - Initial submission 
 // 20150923 - Add check to see and handle if the user has stopped the scan
 

--- a/passive/Find Emails.js
+++ b/passive/Find Emails.js
@@ -1,8 +1,7 @@
 // Email finder by freakyclown@gmail.com
 // Based on:
 // PassiveHTMLCommentFinder.js
-// kingthorin+owaspzap@gmail.com
-// 20150106 - Updated by kingthorin+owaspzap@gmail.com to handle addresses (such as gmail) with alias portion:
+// 20150106 - Updated by kingthorin to handle addresses (such as gmail) with alias portion:
 //     https://support.google.com/mail/answer/12096?hl=en
 //     https://regex101.com/r/sH4vC0/2
 // 20181213 - Update by nil0x42+owaspzap@gmail.com to ignore false positives (such as '*@123' or '$@#!.')

--- a/passive/Find HTML Comments.js
+++ b/passive/Find HTML Comments.js
@@ -5,7 +5,7 @@
 // Right click the script in the Scripts tree and select "enable"  
 
 // PassiveHTMLCommentFinder.js
-// kingthorin+owaspzap@gmail.com
+// Author: kingthorin
 
 // References:
 // RegEx Testing: http://regex101.com/r/tX1hS1

--- a/passive/f5_bigip_cookie_internal_ip.js
+++ b/passive/f5_bigip_cookie_internal_ip.js
@@ -7,7 +7,7 @@
 // If an analyzed cookie decodes to a RFC1918 IPv4 address then an alert is raised.
 
 // Ref: https://support.f5.com/kb/en-us/solutions/public/6000/900/sol6917.html
-// Author: kingthorin+owaspzap@gmail.com
+// Author: kingthorin
 // 20150828 - Initial submission
 // 20160117 - Updated to include ipv6 variants - jkbowser[at]gmail[dot]com
 

--- a/standalone/domainFinder.js
+++ b/standalone/domainFinder.js
@@ -2,7 +2,7 @@
 //
 //Inspired partially by fierce domain scanner
 //Partially addresses https://github.com/zaproxy/zaproxy/issues/562
-//Author: kingthorin+owaspzap@gmail.com
+//Author: kingthorin
 //20160207: Initial release.
 
 var DOMAIN=".example.org"; //Update this with the domain you want to do lookups on 

--- a/standalone/historySourceTagger.js
+++ b/standalone/historySourceTagger.js
@@ -3,7 +3,7 @@
 // SRC_Proxied, SRC_Manual, SRC_Other
 // The script can be run multiple times, history entries will only be tagged
 // if they don't already have a tag that starts with TAG_PREFIX as defined below.
-// Author: kingthorin+owaspzap@gmail.com
+// Author: kingthorin
 // 20160207: Initial release
 
 extHist = control.getExtensionLoader().


### PR DESCRIPTION
They don't really need to be email addresses with alias.