### PR TITLE
Copy all ZAP logs in `export_session.py` scan hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Rename AWS signing script.
 - Update descriptions/comments in scripts.
 - standalone/Open Fortune 500 websites in a browser.zst - Fix typo in `http://www,pbfenergy.com`
+- Update export_session script to copy multiple zap files created during log file rotation
 
 ## [17] - 2023-06-28
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Rename AWS signing script.
 - Update descriptions/comments in scripts.
 - standalone/Open Fortune 500 websites in a browser.zst - Fix typo in `http://www,pbfenergy.com`
-- Update export_session script to copy multiple zap files created during log file rotation
 
 ## [17] - 2023-06-28
 ### Added

--- a/other/scan-hooks/export_session.py
+++ b/other/scan-hooks/export_session.py
@@ -4,6 +4,7 @@
 
 from shutil import copy2, copytree
 import os.path
+import glob
 
 # This assumes that you are running as zap - if you run as root change to use /root/.ZAP(_D)
 dev_path = '/home/zap/.ZAP_D'
@@ -14,4 +15,5 @@ def pre_exit(fail_count, warn_count, pass_count):
 	if os.path.exists(dev_path + '/session'):
 		dir = dev_path
 	copytree(dir + '/session', '/zap/wrk/session')
-	copy2(dir + '/zap.log', '/zap/wrk')
+	for zap_file in glob.iglob(dir + '/zap.log*'):
+		copy2(zap_file, '/zap/wrk')


### PR DESCRIPTION
Zap log files are rotated which results in multiple log files.
Updated code to copy all zap log files.