### PR TITLE
Adding a script to encrypt requests using RSA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - extender/arpSyndicateSubdomainDiscovery.js - uses the API of [ARPSyndicate's Subdomain Center](https://www.subdomain.center/)
   to find and add subdomains to the Sites Tree.
 - passive/JavaDisclosure.js - Passive scan for Java error messages leaks
+- httpsender/RsaEncryptPayloadForZap.py - A script that encrypts requests using RSA
 
 ## [18] - 2024-01-29
 ### Added

--- a/httpsender/RsaEncryptPayloadForZap.py
+++ b/httpsender/RsaEncryptPayloadForZap.py
@@ -42,5 +42,8 @@ def sendingRequest(msg, initiator, helper):
 
 
 def responseReceived(msg, initiator, helper):
+    # Restoring the original value of the sent request from before encryption to facilitate work in the Requester module.
+    # Without this change, ZAP would automatically replace the value with an encrypted one. Additionally, to more easily
+    # identify the requests sent to the server in the history, we store the plain text in notes.
     body = msg.getNote()
     msg.setRequestBody(body)

--- a/httpsender/RsaEncryptPayloadForZap.py
+++ b/httpsender/RsaEncryptPayloadForZap.py
@@ -1,0 +1,46 @@
+# RSA Encrypt Payload Script for Zed Attack Proxy - ZAP
+# HelpAddOn Script - HTTPSender
+# Michal Walkowski - https://mwalkowski.github.io/
+#
+# Tested with Jython 14 beta and ZAP 2.14.0
+# Based On: https://mwalkowski.github.io/post/using-burp-python-scripts-to-encrypt-requests-with-rsa-keys/
+# You can test the script's functionality using https://github.com/mwalkowski/api-request-security-poc
+
+
+
+import json
+import base64
+import subprocess
+
+# path to public.pem
+PUBLIC_KEY = "public.pem"
+
+PAYLOAD_PLACEHOLDER = "PAYLOAD"
+PAYLOAD = '{\"keyId\": \"init\", \"encryptedPayload\": \"' + PAYLOAD_PLACEHOLDER + '\"}'
+
+
+def encrypt_body(body):
+    body_b64 = base64.standard_b64encode(json.dumps(body, ensure_ascii=False).encode()).decode()
+
+    cmd = 'printf %s "{}" | openssl pkeyutl -encrypt -pubin -inkey {} | openssl base64'.format(body_b64, PUBLIC_KEY)
+    process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+    output, err = process.communicate()
+    if err.decode() != "":
+        raise Exception(err)
+
+    return output.decode().replace("\n", "")
+
+
+def sendingRequest(msg, initiator, helper):
+    body = msg.getRequestBody().toString()
+    msg.setNote(body)
+    body = json.loads(body)
+    encrypted_body = encrypt_body(body)
+    new_payload = PAYLOAD.replace(PAYLOAD_PLACEHOLDER, encrypted_body)
+    msg.setRequestBody(new_payload)
+    msg.getRequestHeader().setHeader("content-length", str(len(new_payload)))
+
+
+def responseReceived(msg, initiator, helper):
+    body = msg.getNote()
+    msg.setRequestBody(body)

--- a/httpsender/RsaEncryptPayloadForZap.py
+++ b/httpsender/RsaEncryptPayloadForZap.py
@@ -38,7 +38,7 @@ def sendingRequest(msg, initiator, helper):
     encrypted_body = encrypt_body(body)
     new_payload = PAYLOAD.replace(PAYLOAD_PLACEHOLDER, encrypted_body)
     msg.setRequestBody(new_payload)
-    msg.getRequestHeader().setHeader("content-length", str(len(new_payload)))
+    msg.getRequestHeader().setContentLength(msg.getRequestBody().length())
 
 
 def responseReceived(msg, initiator, helper):


### PR DESCRIPTION
Hi All,

I've prepared a script for ZAP that allows encrypting the message body using RSA. I decided to reuse httpsender because I wanted this script to run in every possible mode (whether we're using proxy/requester, etc). This way, I also have the option for manual inspection of what I'm sending to the server. I've also prepared a similar solution for Burp and described everything under this [link](https://mwalkowski.github.io/post/using-burp-python-scripts-to-encrypt-requests-with-rsa-keys/).