### PR TITLE
Implement `getMetadata` for active JS scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Use Prettier to format all JavaScript scripts.
+- Update the following scripts to implement the `getMetadata()` function:
+  - active/Cross Site WebSocket Hijacking.js
+  - active/cve-2019-5418.js
+  - active/gof_lite.js
+  - active/JWT None Exploit.js
+  - active/SSTI.js
 
 ## [18] - 2024-01-29
 ### Added

--- a/active/JWT None Exploit.js
+++ b/active/JWT None Exploit.js
@@ -4,18 +4,36 @@ var Cookie = Java.type("java.net.HttpCookie");
 var Base64 = Java.type("java.util.Base64");
 var String = Java.type("java.lang.String");
 
-// Exploit information, used for raising alerts
-var RISK = 3;
-var CONFIDENCE = 2;
-var TITLE = "JWT None Exploit";
-var DESCRIPTION =
-  "The application's JWT implementation allows for the usage of the 'none' algorithm, which bypasses the JWT hash verification.";
-var SOLUTION =
-  "Use a secure JWT library, and (if your library supports it) restrict the allowed hash algorithms.";
-var REFERENCE =
-  "https://www.sjoerdlangkemper.nl/2016/09/28/attacking-jwt-authentication/";
-var CWEID = 347; // CWE-347: Improper Verification of Cryptographic Signature
-var WASCID = 15; // WASC-15: Application Misconfiguration
+var ScanRuleMetadata = Java.type(
+  "org.zaproxy.addon.commonlib.scanrules.ScanRuleMetadata"
+);
+var CommonAlertTag = Java.type("org.zaproxy.addon.commonlib.CommonAlertTag");
+
+function getMetadata() {
+  return ScanRuleMetadata.fromYaml(`
+id: 100026
+name: JWT None Exploit
+description: >
+  The application's JWT implementation allows for the usage of the 'none' algorithm,
+  which bypasses the JWT hash verification.
+solution: >
+  Use a secure JWT library, and (if your library supports it) restrict the allowed hash algorithms.
+references:
+  - https://www.sjoerdlangkemper.nl/2016/09/28/attacking-jwt-authentication/
+category: server
+risk: high
+confidence: medium
+cweId: 347  # CWE-347: Improper Verification of Cryptographic Signature, http://cwe.mitre.org/data/definitions/347.html
+wascId: 15  # WASC-15: Application Misconfiguration
+alertTags:
+  ${CommonAlertTag.OWASP_2021_A01_BROKEN_AC.getTag()}: ${CommonAlertTag.OWASP_2021_A01_BROKEN_AC.getValue()}
+  ${CommonAlertTag.OWASP_2017_A02_BROKEN_AUTH.getTag()}: ${CommonAlertTag.OWASP_2017_A02_BROKEN_AUTH.getValue()}
+  ${CommonAlertTag.WSTG_V42_CRYP_04_WEAK_CRYPTO.getTag()}: ${CommonAlertTag.WSTG_V42_CRYP_04_WEAK_CRYPTO.getValue()}
+status: alpha
+codeLink: https://github.com/zaproxy/community-scripts/blob/main/active/JWT%20None%20Exploit.js
+helpLink: https://www.zaproxy.org/docs/desktop/addons/community-scripts/
+`);
+}
 
 function b64encode(string) {
   // Terminate the string with a null byte prior to encoding. I suspect that
@@ -128,20 +146,8 @@ function scanNode(as, msg) {
 
 function raise_alert(msg, cookie, payload, as) {
   print("Vulnerability found, sending alert");
-  as.raiseAlert(
-    RISK,
-    CONFIDENCE,
-    TITLE,
-    DESCRIPTION,
-    msg.getRequestHeader().getURI().toString(),
-    "",
-    "",
-    "",
-    SOLUTION,
-    "Cookie: " + cookie.getName() + "=" + payload,
-    REFERENCE,
-    CWEID,
-    WASCID,
-    msg
-  );
+  as.newAlert()
+    .setEvidence("Cookie: " + cookie.getName() + "=" + payload)
+    .setMessage(msg)
+    .raise();
 }

--- a/active/SSTI.js
+++ b/active/SSTI.js
@@ -11,8 +11,36 @@
 var LoggerManager = Java.type("org.apache.logging.log4j.LogManager");
 var log = LoggerManager.getLogger("SSTI");
 
-// HasMap for alertTags
-var HashMap = Java.type("java.util.HashMap");
+var ScanRuleMetadata = Java.type(
+  "org.zaproxy.addon.commonlib.scanrules.ScanRuleMetadata"
+);
+
+function getMetadata() {
+  return ScanRuleMetadata.fromYaml(`
+id: 100033
+name: Server Side Template Injection
+description: >
+  Server Side Template Injection (SSTI) occurs when user input is directly embedded into the template without any
+  proper sanitization, a hacker can use this vulnerability to inject malicious code and try to achieve remote code execution.
+solution: >
+  Always use proper functions provided by the template engine to insert data,
+  if that is not possible try to sanitize user input as efficiently as possible.
+references:
+  - https://portswigger.net/research/server-side-template-injection
+category: injection
+risk: high
+confidence: medium
+cweId: 20  # CWE-20: Improper Input Validation
+wascId: 20  # WASC-20: Improper Input Handling
+alertTags:
+  ${CommonAlertTag.OWASP_2021_A03_INJECTION.getTag()}: ${CommonAlertTag.OWASP_2021_A03_INJECTION.getValue()}
+  ${CommonAlertTag.OWASP_2017_A01_INJECTION.getTag()}: ${CommonAlertTag.OWASP_2017_A01_INJECTION.getValue()}
+  ${CommonAlertTag.WSTG_V42_INPV_18_SSTI.getTag()}: ${CommonAlertTag.WSTG_V42_INPV_18_SSTI.getValue()}
+status: alpha
+codeLink: https://github.com/zaproxy/community-scripts/blob/main/active/SSTI.js
+helpLink: https://www.zaproxy.org/docs/desktop/addons/community-scripts/
+`);
+}
 
 function logger() {
   print("[" + this["zap.script.name"] + "] " + arguments[0]);
@@ -168,44 +196,18 @@ function raiseAlert(as, msg, payload, evidence, confidence, param, engine) {
   var badErrors = ["Infinity", "INF"];
 
   //Alert variables
-  var pluginId = 100033;
   var alertName = "Server Side Template Injection";
   if (badErrors.indexOf(engine) == -1) {
     alertName += " - " + toTitleCase(engine);
   }
-  var alertDesc =
-    "Server Side Template Injection (SSTI) occurs when user input is directly embedded into the template without any proper sanitization, a hacker can use this vulnerability to inject malicious code and try to achieve remote code execution.";
-  var alertSol =
-    "Always use proper functions provided by the template engine to insert data, if that is not possible try to sanitize user input as efficiently as possible.";
-  var alertRef =
-    "https://portswigger.net/research/server-side-template-injection";
-  var cweId = 20; // Improper Input Validation
-  var wascId = 20; // Improper Input Handling
-  var alertTags = new HashMap();
-  alertTags.put(
-    "OWASP_2021_A03",
-    "https://owasp.org/Top10/A03_2021-Injection/"
-  );
-  alertTags.put(
-    "OWASP_2017_A01",
-    "https://owasp.org/www-project-top-ten/2017/A1_2017-Injection.html"
-  );
 
   as.newAlert()
-    .setAlertId(pluginId)
-    .setRisk(3)
     .setConfidence(confidence)
     .setName(alertName)
-    .setDescription(alertDesc)
     .setParam(param)
     .setAttack(payload)
     .setEvidence(evidence)
-    .setSolution(alertSol)
-    .setReference(alertRef)
-    .setCweId(cweId)
-    .setWascId(wascId)
     .setMessage(msg)
-    .setTags(alertTags)
     .raise();
 }
 

--- a/active/cve-2019-5418.js
+++ b/active/cve-2019-5418.js
@@ -1,34 +1,39 @@
-// Note that new active scripts will initially be disabled
-// Right click the script in the Scripts tree and select "enable"
-
 // This active scanner script checks for CVE-2019-5418
 
-/**
- * Scans a "node", i.e. an individual entry in the Sites Tree.
- * The scanNode function will typically be called once for every page.
- *
- * @param as - the ActiveScan parent object that will do all the core interface tasks
- *     (i.e.: sending and receiving messages, providing access to Strength and Threshold settings,
- *     raising alerts, etc.). This is an ScriptsActiveScanner object.
- * @param msg - the HTTP Message being scanned. This is an HttpMessage object.
- */
-function scanNode(as, msg) {
-  // Set some details we will need for alerts later
-  var alertRisk = 3;
-  var alertConfidence = 2;
-  var alertTitle = "CVE-2019-5418 - File Content Disclosure";
-  var alertDesc =
-    "The application seems to be subject to CVE-2019-5418. \
-By sending a specially crafted request it was possible to have the target return \
-data from the server file system.";
-  var alertSolution =
-    "Upgrade to a version of Ruby/Rails where this issue is fixed. (See references for further details).";
-  var alertInfo =
-    "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5418\nhttps://github.com/mpgn/CVE-2019-5418";
-  var cweId = 74; //Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-  var wascId = 33; // Path Traversal
-  var url = msg.getRequestHeader().getURI().toString();
+var ScanRuleMetadata = Java.type(
+  "org.zaproxy.addon.commonlib.scanrules.ScanRuleMetadata"
+);
+var CommonAlertTag = Java.type("org.zaproxy.addon.commonlib.CommonAlertTag");
 
+function getMetadata() {
+  return ScanRuleMetadata.fromYaml(`
+id: 100029
+name: "File Content Disclosure (CVE-2019-5418)"
+description: >
+  The application seems to be subject to CVE-2019-5418.
+  By sending a specially crafted request it was possible to have the target return
+  data from the server file system.
+solution: >
+  Upgrade to a version of Ruby/Rails where this issue is fixed. (See references for further details).
+references:
+  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5418
+  - https://github.com/mpgn/CVE-2019-5418
+category: injection
+risk: high
+confidence: medium
+cweId: 74  # CWE-74: Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
+wascId: 33  # WASC-33: Path Traversal
+alertTags:
+  ${CommonAlertTag.OWASP_2021_A03_INJECTION.getTag()}: ${CommonAlertTag.OWASP_2021_A03_INJECTION.getValue()}
+  ${CommonAlertTag.OWASP_2017_A01_INJECTION.getTag()}: ${CommonAlertTag.OWASP_2017_A01_INJECTION.getValue()}
+  ${CommonAlertTag.WSTG_V42_ATHZ_01_DIR_TRAVERSAL.getTag()}: ${CommonAlertTag.WSTG_V42_ATHZ_01_DIR_TRAVERSAL.getValue()}
+status: alpha
+codeLink: https://github.com/zaproxy/community-scripts/blob/main/active/cve-2019-5418.js
+helpLink: https://www.zaproxy.org/docs/desktop/addons/community-scripts/
+`);
+}
+
+function scanNode(as, msg) {
   var msg2 = msg.cloneRequest();
   msg2
     .getRequestHeader()
@@ -40,21 +45,7 @@ data from the server file system.";
   var body = msg2.getResponseBody().toString();
 
   if (re.test(body)) {
-    as.raiseAlert(
-      alertRisk,
-      alertConfidence,
-      alertTitle,
-      alertDesc,
-      url,
-      "",
-      "",
-      alertInfo,
-      alertSolution,
-      body.match(re)[0],
-      cweId,
-      wascId,
-      msg2
-    );
+    as.newAlert().setEvidence(body.match(re)[0]).setMessage(msg2).raise();
     return; // No need to try further
   }
   // Just in case there's a simple WaF
@@ -68,24 +59,6 @@ data from the server file system.";
   re = /127.0.0.1/g;
   body = msg3.getResponseBody().toString();
   if (re.test(body)) {
-    as.raiseAlert(
-      alertRisk,
-      alertConfidence,
-      alertTitle,
-      alertDesc,
-      url,
-      "",
-      "",
-      alertInfo,
-      alertSolution,
-      body.match(re)[0],
-      cweId,
-      wascId,
-      msg3
-    );
+    as.newAlert().setEvidence(body.match(re)[0]).setMessage(msg3).raise();
   }
-}
-
-function scan(as, msg, param, value) {
-  //Unused
 }


### PR DESCRIPTION
Part of #440.

Also add relevant alert tags and assign categories. The scan rule IDs for these scripts were taken from the [scanners.md](https://github.com/zaproxy/zaproxy/blob/aedad6818c562a741115333a660d5de09f1780d9/docs/scanners.md) file.

The status of these scripts has been set to `alpha` since community-scripts is an alpha add-on.