### PR TITLE
Implement `getMetadata` for some Passive scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - active/gof_lite.js
   - active/JWT None Exploit.js
   - active/SSTI.js
+  - passive/clacks.js
+  - passive/CookieHTTPOnly.js
+  - passive/detect_csp_notif_and_reportonly.js
+  - passive/detect_samesite_protection.js
+  - passive/f5_bigip_cookie_internal_ip.js
 
 ## [18] - 2024-01-29
 ### Added

--- a/active/Cross Site WebSocket Hijacking.js
+++ b/active/Cross Site WebSocket Hijacking.js
@@ -61,8 +61,8 @@ references:
 category: server
 risk: high
 confidence: medium
-cweId: 346  # CWE-346: Origin Validation Error, http://cwe.mitre.org/data/definitions/346.html
-wascId: 9  # WASC-9 Cross Site Request Forgery, http://projects.webappsec.org/w/page/13246919/Cross%20Site%20Request%20Forgery
+cweId: 346  # CWE-346: Origin Validation Error
+wascId: 9  # WASC-9 Cross Site Request Forgery
 alertTags:
   ${CommonAlertTag.OWASP_2021_A01_BROKEN_AC.getTag()}: ${CommonAlertTag.OWASP_2021_A01_BROKEN_AC.getValue()}
   ${CommonAlertTag.OWASP_2017_A05_BROKEN_AC.getTag()}: ${CommonAlertTag.OWASP_2017_A05_BROKEN_AC.getValue()}

--- a/active/JWT None Exploit.js
+++ b/active/JWT None Exploit.js
@@ -23,7 +23,7 @@ references:
 category: server
 risk: high
 confidence: medium
-cweId: 347  # CWE-347: Improper Verification of Cryptographic Signature, http://cwe.mitre.org/data/definitions/347.html
+cweId: 347  # CWE-347: Improper Verification of Cryptographic Signature
 wascId: 15  # WASC-15: Application Misconfiguration
 alertTags:
   ${CommonAlertTag.OWASP_2021_A01_BROKEN_AC.getTag()}: ${CommonAlertTag.OWASP_2021_A01_BROKEN_AC.getValue()}

--- a/passive/CookieHTTPOnly.js
+++ b/passive/CookieHTTPOnly.js
@@ -1,37 +1,32 @@
 // Cookie HttpOnly Check by freakyclown@gmail.com
 
-function scan(ps, msg, src) {
-  var alertRisk = 1;
-  var alertConfidence = 2;
-  var alertTitle = "Cookie set without HTTPOnly Flag(script)";
-  var alertDesc =
-    "A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.";
-  var alertSolution = "Ensure that the HttpOnly flag is set for all cookies.";
+var ScanRuleMetadata = Java.type(
+  "org.zaproxy.addon.commonlib.scanrules.ScanRuleMetadata"
+);
 
-  var cweId = 0;
-  var wascId = 13;
+function getMetadata() {
+  return ScanRuleMetadata.fromYaml(`
+id: 100003
+name: Cookie Set Without HttpOnly Flag
+description: >
+  A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript.
+  If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site.
+  If this is a session cookie then session hijacking may be possible.
+solution: Ensure that the HttpOnly flag is set for all cookies.
+risk: low
+confidence: medium
+cweId: 0
+wascId: 13  # WASC-13: Information Leakage
+status: alpha
+`);
+}
 
-  var url = msg.getRequestHeader().getURI().toString();
-  var headers = msg.getResponseHeader().getHeaders("Set-Cookie");
-
-  if (headers != null) {
+function scan(helper, msg, src) {
+  var cookies = msg.getResponseHeader().getHeaders("Set-Cookie");
+  if (cookies != null) {
     var re_noflag = /([Hh][Tt][Tt][Pp][Oo][Nn][Ll][Yy])/g;
-    if (!re_noflag.test(headers)) {
-      ps.raiseAlert(
-        alertRisk,
-        alertConfidence,
-        alertTitle,
-        alertDesc,
-        url,
-        "",
-        "",
-        "",
-        alertSolution,
-        headers,
-        cweId,
-        wascId,
-        msg
-      );
+    if (!re_noflag.test(cookies)) {
+      helper.newAlert().setMessage(msg).setEvidence(cookies).raise();
     }
   }
 }

--- a/passive/clacks.js
+++ b/passive/clacks.js
@@ -1,35 +1,30 @@
 // Clacks Header Check by freakyclown@gmail.com
 
-function scan(ps, msg, src) {
-  var alertRisk = 0;
-  var alertConfidence = 3;
-  var alertTitle = "Server is running on CLACKS - GNU Terry Pratchett";
-  var alertDesc =
-    "The web/application server is running over the CLACKS network, some say its turtles/IP, some says its turtles all the way down the layer stack.";
-  var alertSolution =
-    "Give the sys admin a high five and rejoice in the disc world.";
+var ScanRuleMetadata = Java.type(
+  "org.zaproxy.addon.commonlib.scanrules.ScanRuleMetadata"
+);
 
-  var cweId = 200;
-  var wascId = 13;
+function getMetadata() {
+  return ScanRuleMetadata.fromYaml(`
+id: 100002
+name: Server is running on Clacks - GNU Terry Pratchett
+description: > 
+  The web/application server is running over the Clacks network, some say it's turtles/IP, 
+  some say it's turtles all the way down the layer stack.
+solution: Give the sysadmin a high five and rejoice in the disc world.
+references:
+  - https://xclacksoverhead.org/home/about
+risk: info
+confidence: high
+cweId: 200  # CWE-200: Exposure of Sensitive Information to an Unauthorized Actor
+wascId: 13  # WASC-13: Information Leakage
+status: alpha
+`);
+}
 
-  var url = msg.getRequestHeader().getURI().toString();
+function scan(helper, msg, src) {
   var headers = msg.getResponseHeader().getHeaders("X-Clacks-Overhead");
-
   if (headers != null) {
-    ps.raiseAlert(
-      alertRisk,
-      alertConfidence,
-      alertTitle,
-      alertDesc,
-      url,
-      "",
-      "",
-      "",
-      alertSolution,
-      headers,
-      cweId,
-      wascId,
-      msg
-    );
+    helper.newAlert().setMessage(msg).setEvidence(headers).raise();
   }
 }


### PR DESCRIPTION
Part of #440.

- passive/clacks.js
- passive/CookieHTTPOnly.js
- passive/detect_csp_notif_and_reportonly.js
- passive/detect_samesite_protection.js
- passive/f5_bigip_cookie_internal_ip.js

Also, update some active scripts to be consistent with adding URLs to CWE and WASC IDs.