### PR TITLE
feat: add Ory Kratos authentication scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - passive/JavaDisclosure.js - Passive scan for Java error messages leaks
 - httpsender/RsaEncryptPayloadForZap.py - A script that encrypts requests using RSA
 - selenium/FillOTPInMFA.js - A script that fills the OTP in MFA
+- authentication/KratosApiAuthentication.js - A script to authenticate with Kratos using the API flow
+- authentication/KratosBrowserAuthentication.js - A script to authenticate with Kratos using the browser flow
 
 ### Changed
 - Use Prettier to format all JavaScript scripts.

--- a/authentication/KratosApiAuthentication.js
+++ b/authentication/KratosApiAuthentication.js
@@ -1,8 +1,10 @@
 /*
  * This script is used to authenticate a user using Ory Kratos self-service API for clients without browsers.
  *
- * Authentication Verification can be configured with a Logged In Regex as something like:
- *  \Qactive.*
+ * Authentication Verification can be configured with the following rule:
+ * - Verification Strategy: Poll the Specified URL
+ * - Regex Pattern used to identify Logged In message: \Qactive.*
+ * - URL to poll: <Kratos Base URL>/sessions/whoami
  *
  * Zap must be configured to use HTTP header-based session management with the value: {%json:session_token%}
  *

--- a/authentication/KratosApiAuthentication.js
+++ b/authentication/KratosApiAuthentication.js
@@ -11,12 +11,12 @@
  */
 
 const HttpRequestHeader = Java.type(
-  'org.parosproxy.paros.network.HttpRequestHeader'
+  "org.parosproxy.paros.network.HttpRequestHeader"
 );
-const HttpHeader = Java.type('org.parosproxy.paros.network.HttpHeader');
-const URI = Java.type('org.apache.commons.httpclient.URI');
+const HttpHeader = Java.type("org.parosproxy.paros.network.HttpHeader");
+const URI = Java.type("org.apache.commons.httpclient.URI");
 const AuthenticationHelper = Java.type(
-  'org.zaproxy.zap.authentication.AuthenticationHelper'
+  "org.zaproxy.zap.authentication.AuthenticationHelper"
 );
 
 /**
@@ -43,12 +43,12 @@ const AuthenticationHelper = Java.type(
  * @returns {Object} The HTTP message used to perform the authentication.
  */
 function authenticate(helper, paramsValues, credentials) {
-  print('Authenticating via Ory Kratos...');
+  print("Authenticating via Ory Kratos...");
 
   // Step 1: Initialize the login flow
-  const kratosBaseUri = paramsValues.get('Kratos Base URL');
+  const kratosBaseUri = paramsValues.get("Kratos Base URL");
   const initLoginUri = new URI(
-    kratosBaseUri + '/self-service/login/api',
+    kratosBaseUri + "/self-service/login/api",
     false
   );
   const initLoginMsg = helper.prepareMessage();
@@ -59,10 +59,10 @@ function authenticate(helper, paramsValues, credentials) {
       HttpHeader.HTTP11
     )
   );
-  print('Sending GET request to ' + initLoginUri);
+  print("Sending GET request to " + initLoginUri);
   helper.sendAndReceive(initLoginMsg);
   print(
-    'Received response status code: ' +
+    "Received response status code: " +
       initLoginMsg.getResponseHeader().getStatusCode()
   );
   AuthenticationHelper.addAuthMessageToHistory(initLoginMsg);
@@ -73,9 +73,9 @@ function authenticate(helper, paramsValues, credentials) {
   const loginUri = new URI(actionUrl, false);
   const loginMsg = helper.prepareMessage();
   const requestBody = JSON.stringify({
-    method: 'password',
-    identifier: credentials.getParam('username'),
-    password: credentials.getParam('password'),
+    method: "password",
+    identifier: credentials.getParam("username"),
+    password: credentials.getParam("password"),
   });
   loginMsg.setRequestBody(requestBody);
 
@@ -89,15 +89,15 @@ function authenticate(helper, paramsValues, credentials) {
   // Build the POST request header
   loginMsg
     .getRequestHeader()
-    .setHeader(HttpHeader.CONTENT_TYPE, 'application/json');
+    .setHeader(HttpHeader.CONTENT_TYPE, "application/json");
   loginMsg
     .getRequestHeader()
     .setContentLength(loginMsg.getRequestBody().length());
 
-  print('Sending POST request to ' + loginUri);
+  print("Sending POST request to " + loginUri);
   helper.sendAndReceive(loginMsg, false);
   print(
-    'Received response status code: ' +
+    "Received response status code: " +
       loginMsg.getResponseHeader().getStatusCode()
   );
   AuthenticationHelper.addAuthMessageToHistory(loginMsg);
@@ -111,7 +111,7 @@ function authenticate(helper, paramsValues, credentials) {
  * @returns {Array<string>} An array of required parameter names.
  */
 function getRequiredParamsNames() {
-  return ['Kratos Base URL'];
+  return ["Kratos Base URL"];
 }
 
 /**
@@ -129,5 +129,5 @@ function getOptionalParamsNames() {
  * @returns {Array<string>} An array of credentials parameter names.
  */
 function getCredentialsParamsNames() {
-  return ['username', 'password'];
+  return ["username", "password"];
 }

--- a/authentication/KratosApiAuthentication.js
+++ b/authentication/KratosApiAuthentication.js
@@ -49,10 +49,7 @@ function authenticate(helper, paramsValues, credentials) {
 
   // Step 1: Initialize the login flow
   const kratosBaseUri = paramsValues.get("Kratos Base URL");
-  const initLoginUri = new URI(
-    kratosBaseUri + "/self-service/login/api",
-    true
-  );
+  const initLoginUri = new URI(kratosBaseUri + "/self-service/login/api", true);
   const initLoginMsg = helper.prepareMessage();
   initLoginMsg.setRequestHeader(
     new HttpRequestHeader(

--- a/authentication/KratosApiAuthentication.js
+++ b/authentication/KratosApiAuthentication.js
@@ -3,10 +3,10 @@
  *
  * Authentication Verification can be configured with the following rule:
  * - Verification Strategy: Poll the Specified URL
- * - Regex Pattern used to identify Logged In message: \Qactive.*
+ * - Regex Pattern used to identify Logged In message: active.*
  * - URL to poll: <Kratos Base URL>/sessions/whoami
  *
- * Zap must be configured to use HTTP header-based session management with the value: {%json:session_token%}
+ * ZAP must be configured to use HTTP header-based session management with the value: {%json:session_token%}
  *
  * @author Edouard Maleix <ed@getlarge.eu>
  * @see https://www.ory.sh/docs/kratos/self-service/flows/user-login#login-for-api-clients-and-clients-without-browsers
@@ -51,7 +51,7 @@ function authenticate(helper, paramsValues, credentials) {
   const kratosBaseUri = paramsValues.get("Kratos Base URL");
   const initLoginUri = new URI(
     kratosBaseUri + "/self-service/login/api",
-    false
+    true
   );
   const initLoginMsg = helper.prepareMessage();
   initLoginMsg.setRequestHeader(

--- a/authentication/KratosApiAuthentication.js
+++ b/authentication/KratosApiAuthentication.js
@@ -1,0 +1,133 @@
+/*
+ * This script is used to authenticate a user using Ory Kratos self-service API for clients without browsers.
+ *
+ * Authentication Verification can be configured with a Logged In Regex as something like:
+ *  \Qactive.*
+ *
+ * Zap must be configured to use HTTP header-based session management with the value: {%json:session_token%}
+ *
+ * @author Edouard Maleix <ed@getlarge.eu>
+ * @see https://www.ory.sh/docs/kratos/self-service/flows/user-login#login-for-api-clients-and-clients-without-browsers
+ */
+
+const HttpRequestHeader = Java.type(
+  'org.parosproxy.paros.network.HttpRequestHeader'
+);
+const HttpHeader = Java.type('org.parosproxy.paros.network.HttpHeader');
+const URI = Java.type('org.apache.commons.httpclient.URI');
+const AuthenticationHelper = Java.type(
+  'org.zaproxy.zap.authentication.AuthenticationHelper'
+);
+
+/**
+ * @typedef {Object} AuthHelper
+ * @property {function(): Object} prepareMessage - Prepares an HTTP message.
+ * @property {function(Object, boolean=): void} sendAndReceive - Sends the HTTP message and receives the response.
+ */
+
+/**
+ * @typedef {Object} ParamsValues
+ * @property {function(string): string} get - Gets the value of a parameter.
+ * @property {function(string): void} set - Sets the value of a parameter.
+ */
+
+/**
+ * @typedef {Object} Credentials
+ * @property {function(string): string} getParam - Gets the value of a parameter. The param	names are the ones returned by the getCredentialsParamsNames() below
+ */
+
+/**
+ * @param {AuthHelper} helper - The authentication helper object provided by ZAP.
+ * @param {ParamsValues} paramsValues - The map of parameter values configured in the Session Properties - Authentication panel.
+ * @param {Credentials} credentials - an object containing the credentials values, as configured in the Session Properties - Users panel.
+ * @returns {Object} The HTTP message used to perform the authentication.
+ */
+function authenticate(helper, paramsValues, credentials) {
+  print('Authenticating via Ory Kratos...');
+
+  // Step 1: Initialize the login flow
+  const kratosBaseUri = paramsValues.get('Kratos Base URL');
+  const initLoginUri = new URI(
+    kratosBaseUri + '/self-service/login/api',
+    false
+  );
+  const initLoginMsg = helper.prepareMessage();
+  initLoginMsg.setRequestHeader(
+    new HttpRequestHeader(
+      HttpRequestHeader.GET,
+      initLoginUri,
+      HttpHeader.HTTP11
+    )
+  );
+  print('Sending GET request to ' + initLoginUri);
+  helper.sendAndReceive(initLoginMsg);
+  print(
+    'Received response status code: ' +
+      initLoginMsg.getResponseHeader().getStatusCode()
+  );
+  AuthenticationHelper.addAuthMessageToHistory(initLoginMsg);
+
+  // Step 2: Submit login credentials
+  const actionUrl = JSON.parse(initLoginMsg.getResponseBody().toString()).ui
+    .action;
+  const loginUri = new URI(actionUrl, false);
+  const loginMsg = helper.prepareMessage();
+  const requestBody = JSON.stringify({
+    method: 'password',
+    identifier: credentials.getParam('username'),
+    password: credentials.getParam('password'),
+  });
+  loginMsg.setRequestBody(requestBody);
+
+  const requestHeader = new HttpRequestHeader(
+    HttpRequestHeader.POST,
+    loginUri,
+    HttpHeader.HTTP11
+  );
+  loginMsg.setRequestHeader(requestHeader);
+
+  // Build the POST request header
+  loginMsg
+    .getRequestHeader()
+    .setHeader(HttpHeader.CONTENT_TYPE, 'application/json');
+  loginMsg
+    .getRequestHeader()
+    .setContentLength(loginMsg.getRequestBody().length());
+
+  print('Sending POST request to ' + loginUri);
+  helper.sendAndReceive(loginMsg, false);
+  print(
+    'Received response status code: ' +
+      loginMsg.getResponseHeader().getStatusCode()
+  );
+  AuthenticationHelper.addAuthMessageToHistory(loginMsg);
+
+  return loginMsg;
+}
+
+/**
+ * Returns the required parameter names.
+ *
+ * @returns {Array<string>} An array of required parameter names.
+ */
+function getRequiredParamsNames() {
+  return ['Kratos Base URL'];
+}
+
+/**
+ * Returns the optional parameter names.
+ *
+ * @returns {Array<string>} An array of optional parameter names.
+ */
+function getOptionalParamsNames() {
+  return [];
+}
+
+/**
+ * Returns the credentials parameter names.
+ *
+ * @returns {Array<string>} An array of credentials parameter names.
+ */
+function getCredentialsParamsNames() {
+  return ['username', 'password'];
+}

--- a/authentication/KratosBrowserAuthentication.js
+++ b/authentication/KratosBrowserAuthentication.js
@@ -1,8 +1,10 @@
 /*
  * @description This script is used to authenticate a user using Ory Kratos self-service API for browser.
  *
- * Authentication Verification can be configured with a Logged In Regex as something like:
- *  \Qactive.*
+ * Authentication Verification can be configured with the following rule:
+ * - Verification Strategy: Poll the Specified URL
+ * - Regex Pattern used to identify Logged In message: \Qactive.*
+ * - URL to poll: <Kratos Base URL>/sessions/whoami
  *
  * Zap must be configured to use cookie-based session management.
  *

--- a/authentication/KratosBrowserAuthentication.js
+++ b/authentication/KratosBrowserAuthentication.js
@@ -1,0 +1,180 @@
+/*
+ * @description This script is used to authenticate a user using Ory Kratos self-service API for browser.
+ *
+ * Authentication Verification can be configured with a Logged In Regex as something like:
+ *  \Qactive.*
+ *
+ * Zap must be configured to use cookie-based session management.
+ *
+ * @author Edouard Maleix <ed@getlarge.eu>
+ * @see https://www.ory.sh/docs/kratos/self-service/flows/user-login#login-for-server-side-browser-clients
+ */
+
+const HttpRequestHeader = Java.type(
+  'org.parosproxy.paros.network.HttpRequestHeader'
+);
+const HttpHeader = Java.type('org.parosproxy.paros.network.HttpHeader');
+const URI = Java.type('org.apache.commons.httpclient.URI');
+const AuthenticationHelper = Java.type(
+  'org.zaproxy.zap.authentication.AuthenticationHelper'
+);
+const Source = Java.type('net.htmlparser.jericho.Source');
+
+/**
+ * @typedef {Object} AuthHelper
+ * @property {function(): Object} prepareMessage - Prepares an HTTP message.
+ * @property {function(Object, boolean=): void} sendAndReceive - Sends the HTTP message and receives the response.
+ */
+
+/**
+ * @typedef {Object} ParamsValues
+ * @property {function(string): string} get - Gets the value of a parameter.
+ * @property {function(string): void} set - Sets the value of a parameter.
+ */
+
+/**
+ * @typedef {Object} Credentials
+ * @property {function(string): string} getParam - Gets the value of a parameter. The param	names are the ones returned by the getCredentialsParamsNames() below
+ */
+
+/**
+ * @param {AuthHelper} helper - The authentication helper object provided by ZAP.
+ * @param {ParamsValues} paramsValues - The map of parameter values configured in the Session Properties - Authentication panel.
+ * @param {Credentials} credentials - an object containing the credentials values, as configured in the Session Properties - Users panel.
+ * @returns {Object} The HTTP message used to perform the authentication.
+ */
+function authenticate(helper, paramsValues, credentials) {
+  print('Authenticating via Ory Kratos...');
+
+  // Step 1: Initialize the login flow
+  const kratosBaseUri = paramsValues.get('Kratos Base URL');
+  const initLoginUri = new URI(
+    kratosBaseUri + '/self-service/login/browser',
+    false
+  );
+  const initLoginMsg = helper.prepareMessage();
+  initLoginMsg.setRequestHeader(
+    new HttpRequestHeader(
+      HttpRequestHeader.GET,
+      initLoginUri,
+      HttpHeader.HTTP11
+    )
+  );
+  print('Sending GET request to ' + initLoginUri);
+  helper.sendAndReceive(initLoginMsg, true);
+  print(
+    'Received response status code: ' +
+      initLoginMsg.getResponseHeader().getStatusCode()
+  );
+  AuthenticationHelper.addAuthMessageToHistory(initLoginMsg);
+
+  // Step 2: Submit login credentials
+  const actionUrl = getActionurl(initLoginMsg);
+  const loginUri = new URI(actionUrl, false);
+  const loginMsg = helper.prepareMessage();
+  const csrf_token = getCsrfToken(initLoginMsg);
+  const requestBody =
+    'identifier=' +
+    encodeURIComponent(credentials.getParam('username')) +
+    '&password=' +
+    encodeURIComponent(credentials.getParam('password')) +
+    '&method=password' +
+    '&csrf_token=' +
+    encodeURIComponent(csrf_token);
+  loginMsg.setRequestBody(requestBody);
+  const requestHeader = new HttpRequestHeader(
+    HttpRequestHeader.POST,
+    loginUri,
+    HttpHeader.HTTP11
+  );
+  loginMsg.setRequestHeader(requestHeader);
+
+  loginMsg
+    .getRequestHeader()
+    .setHeader(HttpHeader.CONTENT_TYPE, 'application/x-www-form-urlencoded');
+  loginMsg
+    .getRequestHeader()
+    .setContentLength(loginMsg.getRequestBody().length());
+
+  print('Sending POST request to ' + loginUri);
+  //! disable redirect to get the cookies from Kratos
+  helper.sendAndReceive(loginMsg, false);
+  print(
+    'Received response status code: ' +
+      loginMsg.getResponseHeader().getStatusCode()
+  );
+  AuthenticationHelper.addAuthMessageToHistory(loginMsg);
+
+  return loginMsg;
+}
+
+/**
+ *
+ * @param {*} request
+ * @returns
+ */
+function getActionurl(request) {
+  let iterator;
+  let element;
+  let actionUrl;
+  const pageSource =
+    request.getResponseHeader().toString() +
+    request.getResponseBody().toString();
+  const src = new Source(pageSource);
+  const elements = src.getAllElements('form');
+
+  for (iterator = elements.iterator(); iterator.hasNext(); ) {
+    element = iterator.next();
+    actionUrl = element.getAttributeValue('action');
+    break;
+  }
+
+  return actionUrl;
+}
+
+function getCsrfToken(request) {
+  let iterator;
+  let element;
+  let loginToken;
+  const pageSource =
+    request.getResponseHeader().toString() +
+    request.getResponseBody().toString();
+  const src = new Source(pageSource);
+  const elements = src.getAllElements('input');
+
+  for (iterator = elements.iterator(); iterator.hasNext(); ) {
+    element = iterator.next();
+    if (element.getAttributeValue('name') == 'csrf_token') {
+      loginToken = element.getAttributeValue('value');
+      break;
+    }
+  }
+
+  return loginToken;
+}
+/**
+ * Returns the required parameter names.
+ *
+ * @returns {Array<string>} An array of required parameter names.
+ */
+function getRequiredParamsNames() {
+  return ['Kratos Base URL'];
+}
+
+/**
+ * Returns the optional parameter names.
+ *
+ * @returns {Array<string>} An array of optional parameter names.
+ */
+function getOptionalParamsNames() {
+  return [];
+}
+
+/**
+ * Returns the credentials parameter names.
+ *
+ * @returns {Array<string>} An array of credentials parameter names.
+ */
+function getCredentialsParamsNames() {
+  return ['username', 'password'];
+}

--- a/authentication/KratosBrowserAuthentication.js
+++ b/authentication/KratosBrowserAuthentication.js
@@ -11,14 +11,14 @@
  */
 
 const HttpRequestHeader = Java.type(
-  'org.parosproxy.paros.network.HttpRequestHeader'
+  "org.parosproxy.paros.network.HttpRequestHeader"
 );
-const HttpHeader = Java.type('org.parosproxy.paros.network.HttpHeader');
-const URI = Java.type('org.apache.commons.httpclient.URI');
+const HttpHeader = Java.type("org.parosproxy.paros.network.HttpHeader");
+const URI = Java.type("org.apache.commons.httpclient.URI");
 const AuthenticationHelper = Java.type(
-  'org.zaproxy.zap.authentication.AuthenticationHelper'
+  "org.zaproxy.zap.authentication.AuthenticationHelper"
 );
-const Source = Java.type('net.htmlparser.jericho.Source');
+const Source = Java.type("net.htmlparser.jericho.Source");
 
 /**
  * @typedef {Object} AuthHelper
@@ -44,12 +44,12 @@ const Source = Java.type('net.htmlparser.jericho.Source');
  * @returns {Object} The HTTP message used to perform the authentication.
  */
 function authenticate(helper, paramsValues, credentials) {
-  print('Authenticating via Ory Kratos...');
+  print("Authenticating via Ory Kratos...");
 
   // Step 1: Initialize the login flow
-  const kratosBaseUri = paramsValues.get('Kratos Base URL');
+  const kratosBaseUri = paramsValues.get("Kratos Base URL");
   const initLoginUri = new URI(
-    kratosBaseUri + '/self-service/login/browser',
+    kratosBaseUri + "/self-service/login/browser",
     false
   );
   const initLoginMsg = helper.prepareMessage();
@@ -60,10 +60,10 @@ function authenticate(helper, paramsValues, credentials) {
       HttpHeader.HTTP11
     )
   );
-  print('Sending GET request to ' + initLoginUri);
+  print("Sending GET request to " + initLoginUri);
   helper.sendAndReceive(initLoginMsg, true);
   print(
-    'Received response status code: ' +
+    "Received response status code: " +
       initLoginMsg.getResponseHeader().getStatusCode()
   );
   AuthenticationHelper.addAuthMessageToHistory(initLoginMsg);
@@ -74,12 +74,12 @@ function authenticate(helper, paramsValues, credentials) {
   const loginMsg = helper.prepareMessage();
   const csrf_token = getCsrfToken(initLoginMsg);
   const requestBody =
-    'identifier=' +
-    encodeURIComponent(credentials.getParam('username')) +
-    '&password=' +
-    encodeURIComponent(credentials.getParam('password')) +
-    '&method=password' +
-    '&csrf_token=' +
+    "identifier=" +
+    encodeURIComponent(credentials.getParam("username")) +
+    "&password=" +
+    encodeURIComponent(credentials.getParam("password")) +
+    "&method=password" +
+    "&csrf_token=" +
     encodeURIComponent(csrf_token);
   loginMsg.setRequestBody(requestBody);
   const requestHeader = new HttpRequestHeader(
@@ -91,16 +91,16 @@ function authenticate(helper, paramsValues, credentials) {
 
   loginMsg
     .getRequestHeader()
-    .setHeader(HttpHeader.CONTENT_TYPE, 'application/x-www-form-urlencoded');
+    .setHeader(HttpHeader.CONTENT_TYPE, "application/x-www-form-urlencoded");
   loginMsg
     .getRequestHeader()
     .setContentLength(loginMsg.getRequestBody().length());
 
-  print('Sending POST request to ' + loginUri);
+  print("Sending POST request to " + loginUri);
   //! disable redirect to get the cookies from Kratos
   helper.sendAndReceive(loginMsg, false);
   print(
-    'Received response status code: ' +
+    "Received response status code: " +
       loginMsg.getResponseHeader().getStatusCode()
   );
   AuthenticationHelper.addAuthMessageToHistory(loginMsg);
@@ -121,11 +121,11 @@ function getActionurl(request) {
     request.getResponseHeader().toString() +
     request.getResponseBody().toString();
   const src = new Source(pageSource);
-  const elements = src.getAllElements('form');
+  const elements = src.getAllElements("form");
 
   for (iterator = elements.iterator(); iterator.hasNext(); ) {
     element = iterator.next();
-    actionUrl = element.getAttributeValue('action');
+    actionUrl = element.getAttributeValue("action");
     break;
   }
 
@@ -140,12 +140,12 @@ function getCsrfToken(request) {
     request.getResponseHeader().toString() +
     request.getResponseBody().toString();
   const src = new Source(pageSource);
-  const elements = src.getAllElements('input');
+  const elements = src.getAllElements("input");
 
   for (iterator = elements.iterator(); iterator.hasNext(); ) {
     element = iterator.next();
-    if (element.getAttributeValue('name') == 'csrf_token') {
-      loginToken = element.getAttributeValue('value');
+    if (element.getAttributeValue("name") == "csrf_token") {
+      loginToken = element.getAttributeValue("value");
       break;
     }
   }
@@ -158,7 +158,7 @@ function getCsrfToken(request) {
  * @returns {Array<string>} An array of required parameter names.
  */
 function getRequiredParamsNames() {
-  return ['Kratos Base URL'];
+  return ["Kratos Base URL"];
 }
 
 /**
@@ -176,5 +176,5 @@ function getOptionalParamsNames() {
  * @returns {Array<string>} An array of credentials parameter names.
  */
 function getCredentialsParamsNames() {
-  return ['username', 'password'];
+  return ["username", "password"];
 }

--- a/authentication/KratosBrowserAuthentication.js
+++ b/authentication/KratosBrowserAuthentication.js
@@ -3,10 +3,10 @@
  *
  * Authentication Verification can be configured with the following rule:
  * - Verification Strategy: Poll the Specified URL
- * - Regex Pattern used to identify Logged In message: \Qactive.*
+ * - Regex Pattern used to identify Logged In message: active.*
  * - URL to poll: <Kratos Base URL>/sessions/whoami
  *
- * Zap must be configured to use cookie-based session management.
+ * ZAP must be configured to use cookie-based session management.
  *
  * @author Edouard Maleix <ed@getlarge.eu>
  * @see https://www.ory.sh/docs/kratos/self-service/flows/user-login#login-for-server-side-browser-clients
@@ -52,7 +52,7 @@ function authenticate(helper, paramsValues, credentials) {
   const kratosBaseUri = paramsValues.get("Kratos Base URL");
   const initLoginUri = new URI(
     kratosBaseUri + "/self-service/login/browser",
-    false
+    true
   );
   const initLoginMsg = helper.prepareMessage();
   initLoginMsg.setRequestHeader(


### PR DESCRIPTION
## Description

I added two authentication scripts to enable authenticated interacted with web applications relying on [Ory Kratos](https://github.com/ory/kratos).
- `KratosApiAuthentication.js` adds support for the [Native Login flow](https://www.ory.sh/docs/kratos/self-service/flows/user-login#login-for-api-clients-and-clients-without-browsers)
- `KratosABrowserAuthentication.js` adds support for the [Browser Login flow](https://www.ory.sh/docs/kratos/self-service/flows/user-login#login-for-server-side-browser-clients)

I hope they may be useful for others in the Zap community.
