### PR TITLE
Implement `getMetadata` for some more Passive scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - passive/Find Emails.js
   - passive/Find Hashes.js
   - passive/Find HTML Comments.js
+  - passive/Find IBANs.js
+  - passive/Find Internal IPs.js
+  - passive/find_reflected_params.py
+  - passive/HUNT.py
+  - passive/Mutliple Security Header Check.js
 
 ## [18] - 2024-01-29
 ### Added

--- a/passive/Find Internal IPs.js
+++ b/passive/Find Internal IPs.js
@@ -1,17 +1,30 @@
 // RFC1918 internal IP Finder by freakyclown@gmail.com
 
-function scan(ps, msg, src) {
-  var url = msg.getRequestHeader().getURI().toString();
-  var alertRisk = 2;
-  var alertConfidence = 2;
-  var alertTitle = "Private IP address in Body(script)";
-  var alertDesc =
-    "A private IP such as 10.x.x.x, 172.x.x.x, 192.168.x.x or IPV6 fe00:: has been found in the HTTP response body.  This information might be helpful for further attacks targeting internal systems. ";
-  var alertSolution =
-    "Remove the private IP address from the HTTP response body.  For comments, use JSP/ASP comment instead of HTML/JavaScript comment which can be seen by client browsers.";
+var ScanRuleMetadata = Java.type(
+  "org.zaproxy.addon.commonlib.scanrules.ScanRuleMetadata"
+);
 
-  var cweId = 0;
-  var wascId = 0;
+function getMetadata() {
+  return ScanRuleMetadata.fromYaml(`
+id: 100013
+name: Information Disclosure - Private IP Address
+description: >
+  A private IP such as 10.x.x.x, 172.x.x.x, 192.168.x.x or IPV6 fe00:: has been found in the HTTP response body.
+  This information might be helpful for further attacks targeting internal systems.
+solution: >
+  Remove the private IP address from the HTTP response body.
+  For comments, use JSP/ASP comment instead of HTML/JavaScript comment which can be seen by client browsers.
+risk: medium
+confidence: medium
+cweId: 200  # CWE-200: Exposure of Sensitive Information to an Unauthorized Actor
+wascId: 13  # WASC-13: Information Leakage
+status: alpha
+codeLink: https://github.com/zaproxy/community-scripts/blob/main/passive/Find%20Internal%20IPs.js
+helpLink: https://www.zaproxy.org/docs/desktop/addons/community-scripts/
+`);
+}
+
+function scan(helper, msg, src) {
   // regex must appear within /( and )/g
   var re =
     /((172\.\d{1,3}\.\d{1,3}\.\d{1,3})|(192\.168\.\d{1,3}\.\d{1,3})|(10\.\d{1,3}\.\d{1,3}\.\d{1,3})|([fF][eE][89aAbBcCdDeEfF]::))/g;
@@ -42,21 +55,12 @@ function scan(ps, msg, src) {
       while ((comm = re.exec(body))) {
         foundIP.push(comm[0]);
       }
-      ps.raiseAlert(
-        alertRisk,
-        alertConfidence,
-        alertTitle,
-        alertDesc,
-        url,
-        "",
-        "",
-        foundIP.toString(),
-        alertSolution,
-        "",
-        cweId,
-        wascId,
-        msg
-      );
+      helper
+        .newAlert()
+        .setEvidence(foundIP[0])
+        .setOtherInfo(`Other instances: ${foundIP.slice(1).toString()}`)
+        .setMessage(msg)
+        .raise();
     }
   }
 }

--- a/passive/Mutliple Security Header Check.js
+++ b/passive/Mutliple Security Header Check.js
@@ -1,12 +1,33 @@
 // Multiple Security Header checker by freakyclown@gmail.com
 
-function scan(ps, msg, src) {
-  var url = msg.getRequestHeader().getURI().toString();
-  var responseHeader = msg.getResponseHeader().toString();
-  var alertRisk = [0, 1, 2, 3]; //0=informational, 1=low, 2=medium, 3=high
-  var alertConfidence = [0, 1, 2, 3, 4]; //0=fp,1=low,2=medium,3=high,4=confirmed
+var ScanRuleMetadata = Java.type(
+  "org.zaproxy.addon.commonlib.scanrules.ScanRuleMetadata"
+);
+
+function getMetadata() {
+  return ScanRuleMetadata.fromYaml(`
+id: 100016
+name: Missing Security Headers
+description: >
+  Some of the following security headers are missing from the HTTP response:
+  Strict-Transport-Security, Content-Security-Policy,
+  X-XSS-Protection, X-Content-Type-Options, X-Frame-Options.
+solution: >
+  Ensure that your web server, application server, load balancer, etc.
+  is configured to set the missing security headers.
+risk: low
+confidence: high
+cweId: 693  # CWE-693: Protection Mechanism Failure
+wascId: 15  # WASC-15: Application Misconfiguration
+status: alpha
+codeLink: https://github.com/zaproxy/community-scripts/blob/main/passive/Mutliple%20Security%20Header%20Check.js
+helpLink: https://www.zaproxy.org/docs/desktop/addons/community-scripts/
+`);
+}
+
+function scan(helper, msg, src) {
   var alertTitle = [
-    "Strict Transport Security(STS) Header Not Set (script)",
+    "Strict-Transport-Security (HSTS) Header Not Set (script)",
     "Content-Security-Policy (script)",
     "Web Browser XSS Protection Not Enabled (script)",
     "X-Content-Type-Options Header Missing (script)",
@@ -29,27 +50,17 @@ function scan(ps, msg, src) {
     "Most modern Web browsers support the X-Frame-Options HTTP header. Ensure it's set on all web pages returned by your site (if you expect the page to be framed only by pages on your server (e.g. it's part of a FRAMESET) then you'll want to use SAMEORIGIN, otherwise if you never expect the page to be framed, you should use DENY.  ALLOW-FROM allows specific websites to frame the web page in supported web browsers).",
     "",
   ];
-  var cweId = [0, 1];
-  var wascId = [0, 1];
 
   // test sts
   if (msg.getRequestHeader().isSecure()) {
     if (msg.getResponseHeader().getHeaders("Strict-Transport-Security") == null)
-      ps.raiseAlert(
-        alertRisk[1],
-        alertConfidence[3],
-        alertTitle[0],
-        alertDesc[0],
-        url,
-        "",
-        "",
-        "",
-        alertSolution[0],
-        "",
-        cweId[0],
-        wascId[0],
-        msg
-      );
+      helper
+        .newAlert()
+        .setName(alertTitle[0])
+        .setDescription(alertDesc[0])
+        .setSolution(alertSolution[0])
+        .setMessage(msg)
+        .raise();
   }
   // test csp
   if (
@@ -59,83 +70,53 @@ function scan(ps, msg, src) {
       "X-WebKit-CSP",
     ])
   )
-    ps.raiseAlert(
-      alertRisk[1],
-      alertConfidence[3],
-      alertTitle[1],
-      alertDesc[1],
-      url,
-      "",
-      "",
-      "",
-      alertSolution[1],
-      "",
-      cweId[0],
-      wascId[0],
-      msg
-    );
+    helper
+      .newAlert()
+      .setName(alertTitle[1])
+      .setDescription(alertDesc[1])
+      .setSolution(alertSolution[1])
+      .setMessage(msg)
+      .raise();
 
   // test xxs protection
   var re_xss = /(X\-XSS\-Protection\:.+1)/g;
   if (!re_xss.test(responseHeader)) {
     //if its false
-    ps.raiseAlert(
-      alertRisk[1],
-      alertConfidence[3],
-      alertTitle[2],
-      alertDesc[2],
-      url,
-      "",
-      "",
-      "",
-      alertSolution[2],
-      "",
-      cweId[0],
-      wascId[0],
-      msg
-    );
+    helper
+      .newAlert()
+      .setName(alertTitle[2])
+      .setDescription(alertDesc[2])
+      .setSolution(alertSolution[2])
+      .setMessage(msg)
+      .raise();
   }
 
   // test xcontent no sniff protection
   var re_nosniff = /(X\-Content\-Type\-Options\:.*nosniff.*)/g;
   if (!re_nosniff.test(responseHeader)) {
     //if its false
-    ps.raiseAlert(
-      alertRisk[2],
-      alertConfidence[2],
-      alertTitle[3],
-      alertDesc[3],
-      url,
-      "",
-      "",
-      "",
-      alertSolution[3],
-      "",
-      cweId[0],
-      wascId[0],
-      msg
-    );
+    helper
+      .newAlert()
+      .setRisk(2)
+      .setConfidence(2)
+      .setName(alertTitle[3])
+      .setDescription(alertDesc[3])
+      .setSolution(alertSolution[3])
+      .setMessage(msg)
+      .raise();
   }
 
   // test xcontent no sniff protection
   var re_clickjack = /(X\-Frame\-Options\:.+[Dd][Ee][Nn][Yy])/g;
   if (!re_clickjack.test(responseHeader)) {
     //if its false
-    ps.raiseAlert(
-      alertRisk[1],
-      alertConfidence[3],
-      alertTitle[4],
-      alertDesc[4],
-      url,
-      "",
-      "",
-      "",
-      alertSolution[4],
-      "",
-      cweId[0],
-      wascId[0],
-      msg
-    );
+    helper
+      .newAlert()
+      .setName(alertTitle[4])
+      .setDescription(alertDesc[4])
+      .setSolution(alertSolution[4])
+      .setMessage(msg)
+      .raise();
   }
 }
 


### PR DESCRIPTION
Update the following scripts to implement the `getMetadata()` function:

- passive/Find IBANs.js
- passive/Find Internal IPs.js
- passive/find_reflected_params.py
- passive/HUNT.py
- passive/Mutliple Security Header Check.js

Part of #440.