### PR TITLE
Implement `getMetadata` for some more Passive scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Use Prettier to format all JavaScript scripts.
-- Update the following scripts to implement the `getMetadata()` function:
+- Update the following scripts to implement the `getMetadata()` function with revised metadata:
   - active/Cross Site WebSocket Hijacking.js
   - active/cve-2019-5418.js
   - active/gof_lite.js
@@ -34,6 +34,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - passive/find_reflected_params.py
   - passive/HUNT.py
   - passive/Mutliple Security Header Check.js
+  - passive/google_api_keys_finder.js
+  - passive/JavaDisclosure.js
+  - passive/Report non static sites.js
+  - passive/RPO.js
+  - passive/s3.js
 
 ## [18] - 2024-01-29
 ### Added

--- a/passive/Report non static sites.js
+++ b/passive/Report non static sites.js
@@ -4,58 +4,61 @@
 // Note that new passive scripts will initially be disabled
 // Right click the script in the Scripts tree and select "enable"
 
+var ScanRuleMetadata = Java.type(
+  "org.zaproxy.addon.commonlib.scanrules.ScanRuleMetadata"
+);
+
+function getMetadata() {
+  return ScanRuleMetadata.fromYaml(`
+id: 100017
+name: Non Static Site Detected
+description: >
+  A query string or form has been detected in the HTTP response body.
+  This indicates that this may not be a static site.
+solution: >
+  If this is not a static site then ignore or disable this rule.
+risk: info
+confidence: medium
+status: alpha
+codeLink: https://github.com/zaproxy/community-scripts/blob/main/passive/Report%20non%20static%20sites.js
+helpLink: https://www.zaproxy.org/docs/desktop/addons/community-scripts/
+`);
+}
+
 /**
  * Passively scans an HTTP message. The scan function will be called for
  * request/response made via ZAP, actual messages depend on the function
  * "appliesToHistoryType", defined below.
  *
- * @param ps - the PassiveScan parent object that will do all the core interface tasks
+ * @param helper - the PassiveScan parent object that will do all the core interface tasks
  *     (i.e.: providing access to Threshold settings, raising alerts, etc.).
  *     This is an ScriptsPassiveScanner object.
  * @param msg - the HTTP Message being scanned. This is an HttpMessage object.
  * @param src - the Jericho Source representation of the message being scanned.
  */
-function scan(ps, msg, src) {
-  // Test the request and/or response here
+function scan(helper, msg, src) {
   if (msg.getRequestHeader().getURI().getEscapedQuery() != null) {
-    // raiseAlert(risk, int confidence, String name, String description, String uri,
-    //		String param, String attack, String otherInfo, String solution, String evidence,
-    //		int cweId, int wascId, HttpMessage msg)
-    // risk: 0: info, 1: low, 2: medium, 3: high
-    // confidence: 0: falsePositive, 1: low, 2: medium, 3: high, 4: confirmed
-    ps.raiseAlert(
-      3,
-      2,
-      "Non static site (query present)",
-      "A query string has been detected in one of the sites URLs. This indicates that this might well not be a static site",
-      msg.getRequestHeader().getURI().toString(),
-      "",
-      "",
-      "",
-      "If this is not a static site then ignore or disable this script",
-      msg.getRequestHeader().getURI().getEscapedQuery(),
-      0,
-      0,
-      msg
-    );
+    helper
+      .newAlert()
+      .setName("Non Static Site Detected (query present)")
+      .setDescription(
+        "A query string has been detected in the HTTP response body. This indicates that this may not be a static site."
+      )
+      .setEvidence(msg.getRequestHeader().getURI().getEscapedQuery())
+      .setMessage(msg)
+      .raise();
   }
   if (src != null && !src.getFormFields().isEmpty()) {
     // There are form fields
-    ps.raiseAlert(
-      3,
-      2,
-      "Non static site (form present)",
-      "One or more forms have been detected in the response. This indicates that this might well not be a static site",
-      msg.getRequestHeader().getURI().toString(),
-      "",
-      "",
-      "",
-      "If this is not a static site then ignore or disable this script",
-      src.getFormFields().toString(),
-      0,
-      0,
-      msg
-    );
+    helper
+      .newAlert()
+      .setName("Non Static Site Detected (form present)")
+      .setDescription(
+        "One or more forms have been detected in the response. This indicates that this may not be a static site."
+      )
+      .setEvidence(src.getFormFields().toString())
+      .setMessage(msg)
+      .raise();
   }
 }
 

--- a/passive/s3.js
+++ b/passive/s3.js
@@ -1,21 +1,28 @@
 // S3 bucket finder by alishasinghania09@gmail.com
 
-function scan(ps, msg, src) {
-  // populate some parameters which will be needed if s3 bucket url is present
-  var alertRisk = 1;
-  var alertConfidence = 3;
-  var alertTitle = "s3 Bucket URL";
-  var alertDesc = "s3 Bucket URL found in response.";
-  var alertSolution =
-    "Remove s3 Buckets name from response or make sure the permissions in bucket are configured properly.";
-  var cweId = 200;
-  var wascId = 13;
+var ScanRuleMetadata = Java.type(
+  "org.zaproxy.addon.commonlib.scanrules.ScanRuleMetadata"
+);
 
+function getMetadata() {
+  return ScanRuleMetadata.fromYaml(`
+id: 100036
+name: Information Disclosure - Amazon S3 Bucket URL
+description: An Amazon S3 bucket URL was found in the HTTP response body.
+solution: Remove S3 Bucket names from the response or ensure that the permissions in bucket are configured properly.
+risk: low
+confidence: high
+cweId: 200  # CWE-200: Exposure of Sensitive Information to an Unauthorized Actor
+wascId: 13  # WASC-13: Information Leakage
+status: alpha
+codeLink: https://github.com/zaproxy/community-scripts/blob/main/passive/s3.js
+helpLink: https://www.zaproxy.org/docs/desktop/addons/community-scripts/
+`);
+}
+
+function scan(helper, msg, src) {
   // the regex for s3 bucket url and it must appear within /( and )/g
   var re = /((s3:\\[a-zA-Z0-9-\.\\_]+)|((s3-|s3\.)?(.*)\.amazonaws\.com))/g;
-
-  // we need to set the url variable to the request or we cant track the alert later
-  var url = msg.getRequestHeader().getURI().toString();
 
   // If the file type is image jpeg/png , then the scan will be skipped
   var contenttype = msg.getResponseHeader().getHeader("Content-Type");
@@ -39,21 +46,12 @@ function scan(ps, msg, src) {
         founds3bucket.push(buckets[0]);
       }
       //raise the alert
-      ps.raiseAlert(
-        alertRisk,
-        alertConfidence,
-        alertTitle,
-        alertDesc,
-        url,
-        "",
-        "",
-        founds3bucket.toString(),
-        alertSolution,
-        "",
-        cweId,
-        wascId,
-        msg
-      );
+      helper
+        .newAlert()
+        .setEvidence(founds3bucket[0])
+        .setOtherInfo(`Other instances: ${founds3bucket.slice(1).toString()}`)
+        .setMessage(msg)
+        .raise();
     }
   }
 }


### PR DESCRIPTION
Update the following scripts to implement the `getMetadata()` function:
- passive/google_api_keys_finder.js
- passive/JavaDisclosure.js
- passive/Report non static sites.js
- passive/RPO.js
- passive/s3.js

Part of #440.