### PR TITLE
Sync HTTP Sender API Scan script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - passive/Report non static sites.js
   - passive/RPO.js
   - passive/s3.js
+- httpsender/Alert on Unexpected Content Types.js now checks for common content-types (`json`, `xml`, and `yaml`) more consistently.
 
 ## [18] - 2024-01-29
 ### Added

--- a/httpsender/Alert on Unexpected Content Types.js
+++ b/httpsender/Alert on Unexpected Content Types.js
@@ -10,20 +10,9 @@ var extensionAlert = control
   .getExtensionLoader()
   .getExtension(org.zaproxy.zap.extension.alert.ExtensionAlert.NAME);
 
-var expectedTypes = [
-  "application/health+json",
-  "application/json",
-  "application/octet-stream",
-  "application/problem+json",
-  "application/problem+xml",
-  "application/soap+xml",
-  "application/vnd.api+json",
-  "application/xml",
-  "application/x-yaml",
-  "text/x-json",
-  "text/json",
-  "text/yaml",
-];
+var expectedTypes = ["application/octet-stream", "text/plain"];
+
+var expectedTypeGroups = ["json", "yaml", "xml"];
 
 function sendingRequest(msg, initiator, helper) {
   // Nothing to do
@@ -40,7 +29,10 @@ function responseReceived(msg, initiator, helper) {
       if (ctype.indexOf(";") > 0) {
         ctype = ctype.substring(0, ctype.indexOf(";"));
       }
-      if (expectedTypes.indexOf(ctype) < 0) {
+      if (
+        !msg.getResponseHeader().hasContentType(expectedTypeGroups) &&
+        expectedTypes.indexOf(ctype) < 0
+      ) {
         // Another rule will complain if theres no type
 
         var risk = 1; // Low


### PR DESCRIPTION
Sync the HTTP Sender script `Alert on Unexpected Content Types` to match the content-type checks done in Docker API Scan.

Ref zaproxy/zaproxy#8524.