### PR TITLE
Update scripts/READMEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Variant script 'AddUrlParams.js'
 ### Changed
 - Add cautionary note to help and readme.
+- Maintenance and documentation changes.
+
 ### Fixed 
 - Bug in 'Mutliple Security Header Check.js'.
 

--- a/authentication/README.md
+++ b/authentication/README.md
@@ -39,10 +39,6 @@ function authenticate(helper, paramsValues, credentials) {
 	// Set the number of maximum redirects followed to 5 (default is 100). Main purpose is to prevent infinite loops.
 	// helper.getHttpSender().setMaxRedirects(5)
 
-	// Allow circular redirects (default is not allow). Circular redirects happen when a request
-	// redirects to itself, or when a same request was already accessed in a chain of redirects.
-	// helper.getHttpSender().setAllowCircularRedirects(true)
-
 	helper.sendAndReceive(msg);
 
 	return msg;

--- a/httpsender/LogMessages.js
+++ b/httpsender/LogMessages.js
@@ -9,18 +9,9 @@
 // To use this script in the Docker packaged scans use the scan-hook LogRequestsHook.py
 // This script can be used outside of docker but if so change the /zap/wrk/ directory to be a valid local directory.
 
-// 'initiator' is the component the initiated the request:
-//              1       PROXY_INITIATOR
-//              2       ACTIVE_SCANNER_INITIATOR
-//              3       SPIDER_INITIATOR
-//              4       FUZZER_INITIATOR
-//              5       AUTHENTICATION_INITIATOR
-//              6       MANUAL_REQUEST_INITIATOR
-//              8       BEAN_SHELL_INITIATOR
-//              9       ACCESS_CONTROL_SCANNER_INITIATOR
-//              10      AJAX_SPIDER_INITIATOR
-// For the latest list of values see the HttpSender class:
-// https://github.com/zaproxy/zaproxy/blob/main/zap/src/main/java/org/parosproxy/paros/network/HttpSender.java
+// 'initiator' is the component the initiated the request.
+// For the latest list of values see the "Request Initiator" entries in the constants documentation:
+// https://www.zaproxy.org/docs/constants/
 // 'helper' just has one method at the moment: helper.getHttpSender() which returns the HttpSender
 // instance used to send the request.
 

--- a/httpsender/add-more-headers.js
+++ b/httpsender/add-more-headers.js
@@ -1,7 +1,7 @@
 // This HttpSender script adds headers to all messages transmitted by zaproxy,
-// including automated tools. Refer to the HttpSender class definition:
-// https://github.com/zaproxy/zaproxy/blob/main/zap/src/main/java/org/parosproxy/paros/network/HttpSender.java
-// for a list of 'initiator' values (although we don't use them).
+// including automated tools. Refer to the constants documentation:
+// https://www.zaproxy.org/docs/constants/
+// for a list of 'initiator' (Request Initiator) values (although we don't use them).
 
 var ScriptVars = Java.type("org.zaproxy.zap.extension.script.ScriptVars");
 

--- a/selenium/README.md
+++ b/selenium/README.md
@@ -9,18 +9,9 @@ They have access to the launched browser and can interact with it, for example, 
 	The util parameter has the following methods:
 		getWebDriver() Returns the WebDriver: 
 			https://www.javadoc.io/doc/org.seleniumhq.selenium/selenium-api/3.141.0/org/openqa/selenium/WebDriver.html 
-		getRequester() Returns the identifier of the requester:
-		 		1	PROXY_INITIATOR
-		 		2	ACTIVE_SCANNER_INITIATOR
-		 		3	SPIDER_INITIATOR
-		 		4	FUZZER_INITIATOR
-		 		5	AUTHENTICATION_INITIATOR
-		 		6	MANUAL_REQUEST_INITIATOR
-		 		8	BEAN_SHELL_INITIATOR
-		 		9	ACCESS_CONTROL_SCANNER_INITIATOR
-		 		10	AJAX_SPIDER_INITIATOR
-			For the latest list of values see the HttpSender class:
-			https://github.com/zaproxy/zaproxy/blob/main/zap/src/main/java/org/parosproxy/paros/network/HttpSender.java
+		getRequester() Returns the identifier of the requester.
+			For the latest list of values see the "Request Initiator" entries in the constants documentation:
+			https://www.zaproxy.org/docs/constants/
 		getBrowserId() Returns the browser Id, eg "firefox" or "chrome"
 		getProxyAddress() Returns the address of the proxy
 		getProxyPort() Returns the port of the proxy


### PR DESCRIPTION
Remove example method that was deprecated and is no longer functional.
Link to the website documentation for the initiator constants.